### PR TITLE
Fix comparison issue con tPlanarBitmap constructor

### DIFF
--- a/tools/src/common/bitmap.cpp
+++ b/tools/src/common/bitmap.cpp
@@ -60,7 +60,7 @@ tPlanarBitmap::tPlanarBitmap(
 
 	// Determine depth
 	m_ubDepth = 1;
-	for(uint8_t i = 2; i < Palette.m_vColors.size(); i <<= 1) {
+	for(uint16_t i = 2; i < (uint16_t)Palette.m_vColors.size(); i <<= 1) {
 		++m_ubDepth;
 	}
 	if(m_ubDepth > 8) {


### PR DESCRIPTION
If palette size is 256 the uint_t counter on tPlanarBitmap constructor is not enough and we end up on a endless loop because the comparison will always be performed with something less of 256 (unsigned int g
    I changed added 8 more bits to the i counter and casted Palette.m_vColors.size for clarity, in this way 16 bits will be involved on the comparison and they are enough for 256 colors.