### PR TITLE
fix palette conv endless loop if source file does not end with a newline

### DIFF
--- a/tools/src/common/palette.cpp
+++ b/tools/src/common/palette.cpp
@@ -36,6 +36,7 @@ tPalette tPalette::fromGpl(const std::string &szPath)
 
 	// Read colors
 	bool isEnd = false;
+	bool isNextEnd = false;
 	do {
 		std::stringstream ss(szLine);
 		int r, g, b;
@@ -46,9 +47,11 @@ tPalette tPalette::fromGpl(const std::string &szPath)
 		Palette.m_vColors.push_back(Color);
 
 		std::getline(Source, szLine);
-		if(szLine == "") {
+		if(isNextEnd || szLine == "") {
 			isEnd = true;
 		}
+		if(Source.eof())
+			isNextEnd=true;
 	} while(!isEnd);
 
 	fmt::print("Palette color count: {}\n", Palette.m_vColors.size());


### PR DESCRIPTION
Today I had an issue with palette_conv,

if the input file does not end with an empty line, palette_conv is stuck in an endless loop.
My take on this is if the end of file is reached, the szLine is not cleared by std:getline and the exit condition is never met ( szLine == "")

My input file was not generated with gimp, it was a simple copy and paste from another text file, but It had the same structure of yours except for the last line.

Please review my additions, tell me what you think about this issue and eventually merge it into master.
