### PR TITLE
new functions bitmapLoadFromMem and paletteLoadFromMem implemented

### DIFF
--- a/include/ace/utils/bitmap.h
+++ b/include/ace/utils/bitmap.h
@@ -98,6 +98,24 @@ void bitmapLoadFromFile(
 );
 
 /**
+ *  @brief Loads bitmap data from memory to already existing bitmap.
+ *  If source is smaller than destination, you can use uwStartX & uwStartY
+ *  params to load bitmap on given coords.
+ *
+ *  @param pBitMap    Pointer to destination bitmap
+ *  @param pData      Source bitmap pointer.
+ *  @param uwStartX   Start X-coordinate on destination bitmap, 8-pixel aligned.
+ *  @param uwStartY   Start Y-coordinate on destination bitmap
+ *
+ *  @see bitmapCreate
+ *  @see bitmapCreateFromFile
+ */
+void bitmapLoadFromMem(
+	tBitMap *pBitMap,const UBYTE *pData, UWORD uwStartX, UWORD uwStartY
+);
+
+
+/**
  *  @brief Creates bitmap and loads its data from file.
  *  As opposed to bitmapLoadFromFile, this function creates bitmap based
  *  on dimensions, BPP & flags stored in file.

--- a/include/ace/utils/palette.h
+++ b/include/ace/utils/palette.h
@@ -31,6 +31,15 @@ extern "C" {
 void paletteLoad(char *szFileName, UWORD *pPalette, UBYTE ubMaxLength);
 
 /**
+ *  @brief Loads palette from supplied .plt stored in memory to given address.
+ *  @param pData       Palette source pointer.
+ *  @param pPalette    Palette destination pointer.
+ *  @param ubMaxLength Maximum number of colors in palette.
+ */
+void paletteLoadFromMem(const UBYTE *pData , UWORD *pPalette, UBYTE ubMaxLength);
+
+
+/**
  *  @brief Dims palette to given brightness level.
  *  @param pSource      Pointer to source palette.
  *  @param pDest        Pointer to destination palette. May be same as pSource.

--- a/src/ace/utils/palette.c
+++ b/src/ace/utils/palette.c
@@ -25,6 +25,25 @@ void paletteLoad(char *szFileName, UWORD *pPalette, UBYTE ubMaxLength) {
 	logBlockEnd("paletteLoad()");
 }
 
+void paletteLoadFromMem(const UBYTE* pData, UWORD *pPalette, UBYTE ubMaxLength) {
+	UBYTE ubPaletteLength;
+	UBYTE ubCurByte = 0;
+
+	logBlockBegin("paletteLoadFromMem(pPalette: %p, ubMaxLength: %hu)", pPalette, ubMaxLength);
+	
+	memcpy(&ubPaletteLength,&pData[ubCurByte],sizeof(UBYTE));
+	ubCurByte+=sizeof(UBYTE);
+
+	logWrite(" Color count: %u\n", ubPaletteLength);
+	if(ubPaletteLength > ubMaxLength) {
+		ubPaletteLength = ubMaxLength;
+	}
+
+	memcpy(pPalette,&pData[ubCurByte],sizeof(UWORD)*ubPaletteLength);
+
+	logBlockEnd("paletteLoadFromMem()");
+}
+
 void paletteDim(UWORD *pSource, UWORD *pDest, UBYTE ubColorCount, UBYTE ubLevel) {
 	UBYTE r,g,b;
 


### PR DESCRIPTION
As the commit message states I implemented bitmapLoadFromMem and paletteLoadFromMem.
This functions should perform the same exact tasks of their LoadFromFile counterparts.
Sometimes I like to store raw data (images and palettes in this case) on variables rather than relying on .plt and .bm files on filesystem loaded at runtime because in the future I am planning to store the whole game on a NDOS disk where I don't have a filesystem, so this features could be handy.
