### PR TITLE
Vector base register fixed for 68010+ systems

### DIFF
--- a/src/ace/managers/system.c
+++ b/src/ace/managers/system.c
@@ -55,7 +55,7 @@ static const tHwIntVector s_pAceHwInterrupts[SYSTEM_INT_VECTOR_COUNT] = {
 	int5Handler, int6Handler, int7Handler
 };
 static volatile tHwIntVector s_pOsHwInterrupts[SYSTEM_INT_VECTOR_COUNT] = {0};
-static volatile tHwIntVector * const s_pHwVectors = 0;
+static volatile tHwIntVector * s_pHwVectors = 0;
 static volatile tAceInterrupt s_pAceInterrupts[SYSTEM_INT_HANDLER_COUNT] = {{0}};
 static volatile UWORD s_uwAceInts = 0;
 
@@ -300,7 +300,11 @@ void systemCreate(void) {
 	WaitTOF(); // Wait for interlaced screen to finish
 
 	// get VBR location on 68010+ machine
-	// TODO VBR
+	if (SysBase->AttnFlags & AFF_68010)
+	{
+		static UWORD getvbr[] = {0x4e7a, 0x0801, 0x4e73};
+		s_pHwVectors = (tHwIntVector *)Supervisor((void *)getvbr);
+	}
 
 	// Finish disk activity
 	systemFlushIo();

--- a/src/ace/managers/system.c
+++ b/src/ace/managers/system.c
@@ -302,6 +302,7 @@ void systemCreate(void) {
 	WaitTOF(); // Wait for interlaced screen to finish
 
 	// get VBR location on 68010+ machine
+	// http://eab.abime.net/showthread.php?t=65430&page=3
 	if (SysBase->AttnFlags & AFF_68010) {
 		UWORD pGetVbrCode[] = {0x4e7a, 0x0801, 0x4e73};
 		s_pHwVectors = (tHwIntVector *)Supervisor((void *)pGetVbrCode);

--- a/src/ace/managers/system.c
+++ b/src/ace/managers/system.c
@@ -304,7 +304,7 @@ void systemCreate(void) {
 	// get VBR location on 68010+ machine
 	if (SysBase->AttnFlags & AFF_68010)
 	{
-		static UWORD getvbr[] = {0x4e7a, 0x0801, 0x4e73};
+		UWORD getvbr[] = {0x4e7a, 0x0801, 0x4e73};
 		s_pHwVectors = (tHwIntVector *)Supervisor((void *)getvbr);
 	}
 

--- a/src/ace/managers/system.c
+++ b/src/ace/managers/system.c
@@ -302,10 +302,9 @@ void systemCreate(void) {
 	WaitTOF(); // Wait for interlaced screen to finish
 
 	// get VBR location on 68010+ machine
-	if (SysBase->AttnFlags & AFF_68010)
-	{
-		UWORD getvbr[] = {0x4e7a, 0x0801, 0x4e73};
-		s_pHwVectors = (tHwIntVector *)Supervisor((void *)getvbr);
+	if (SysBase->AttnFlags & AFF_68010) {
+		UWORD pGetVbrCode[] = {0x4e7a, 0x0801, 0x4e73};
+		s_pHwVectors = (tHwIntVector *)Supervisor((void *)pGetVbrCode);
 	}
 
 	// Finish disk activity

--- a/src/ace/managers/system.c
+++ b/src/ace/managers/system.c
@@ -11,6 +11,8 @@
 #include <ace/utils/custom.h>
 #include <ace/managers/log.h>
 #include <ace/managers/timer.h>
+#include <exec/execbase.h>
+#include <proto/exec.h>
 
 // There are hardware interrupt vectors
 // Some may be triggered by more than one event - there are 15 events


### PR DESCRIPTION
With this commit interrupts are working on  68010+ systems which don't have VBR at zero.
Code was taken from issue #78 and tested on vampire v600 + coffin r52.
This commit closes #78 hopefully.