### PR TITLE
Fixed tChunkyBitmap::fromPng error handling

### DIFF
--- a/tools/src/common/bitmap.cpp
+++ b/tools/src/common/bitmap.cpp
@@ -73,7 +73,6 @@ tChunkyBitmap tChunkyBitmap::fromPng(const std::string &szPath)
 	uint8_t *pData;
 	auto LodeError = lodepng_decode24_file(&pData, &uWidth, &uHeight, szPath.c_str());
 	if(LodeError) {
-		free(pData);
 		return tChunkyBitmap();
 	}
 


### PR DESCRIPTION
As I tried to build germz from scratch, this line was causing problems. When `lodepng_decode24_file` fails, nothing is allocated under `pData`, so freeing memory cause crashes.