### PR TITLE
Escaping mask color value in CMake

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -152,9 +152,16 @@ endfunction()
 
 function(transformBitmap)
 	cmake_parse_arguments(args "" "TARGET;SOURCE;DESTINATION" "TRANSFORM" ${ARGN})
+
+	# Make is dumb and randomly has problem with unescaped # or not
+	set(argsEscaped "")
+	foreach(arg IN LISTS args_TRANSFORM)
+		list(APPEND argsEscaped "\"${arg}\"")
+	endforeach()
+
 	add_custom_command(
 		OUTPUT ${args_DESTINATION}
-		COMMAND ${ACE_DIR}/tools/bin/bitmap_transform ${args_SOURCE} ${args_DESTINATION} ${args_TRANSFORM}
+		COMMAND ${ACE_DIR}/tools/bin/bitmap_transform ${args_SOURCE} ${args_DESTINATION} ${argsEscaped}
 		WORKING_DIRECTORY ${CMAKE_CURRENT_SOURCE_DIR}
 		DEPENDS ${args_SOURCE}
 	)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -119,7 +119,7 @@ function(convertBitmaps)
 
 		set(extraFlagsPerFile ${extraFlags})
 		if(NOT "${convertBitmaps_MASK_COLOR} " STREQUAL " ")
-			list(APPEND extraFlagsPerFile -mc ${convertBitmaps_MASK_COLOR})
+			list(APPEND extraFlagsPerFile -mc "\"${convertBitmaps_MASK_COLOR}\"")
 			if("${maskPath} " STREQUAL " ")
 				list(APPEND extraFlagsPerFile -nmo)
 			else()


### PR DESCRIPTION
More reliable way to handle `#` in mask color from my end.