### PR TITLE
Fixed clearing interupt instead of dmacon when disabling handler

### DIFF
--- a/src/ace/managers/system.c
+++ b/src/ace/managers/system.c
@@ -757,14 +757,14 @@ void systemSetInt(
 
 	// Re-enable handler or disable it if 0 was passed
 	if(pHandler == 0) {
-		g_pCustom->dmacon = BV(ubIntNumber);
+		g_pCustom->intena = BV(ubIntNumber);
 		s_uwAceIntEna &= ~BV(ubIntNumber);
 	}
 	else {
 		s_pAceInterrupts[ubIntNumber].pHandler = pHandler;
 		s_pAceInterrupts[ubIntNumber].pData = pIntData;
 		s_uwAceIntEna |= BV(ubIntNumber);
-		g_pCustom->intena = DMAF_SETCLR | BV(ubIntNumber);
+		g_pCustom->intena = INTF_SETCLR | BV(ubIntNumber);
 	}
 }
 


### PR DESCRIPTION
Fixed INTF_SETCLR (even if same value as DMAF_SETCLR), to make code more accurate
This bug was messing up sprites when ptplayer is set to use PTPLAYER_USE_VBL: since INTB_VERTB is equal to DMAB_SPRITE.