### PR TITLE
Small Ptplayer optim and fix

### DIFF
--- a/src/ace/managers/ptplayer.c
+++ b/src/ace/managers/ptplayer.c
@@ -1646,8 +1646,8 @@ void ptplayerDestroy(void) {
 	ptplayerStop();
 	// Disable handling of music
 	ptplayerEnableMusic(0);
-	systemSetCiaInt(CIA_B, 0, 0, 0);
-	systemSetCiaInt(CIA_B, 1, 0, 0);
+	ptplayerEnableMainHandler(0);
+	systemSetCiaInt(CIA_B, CIAICRB_TIMER_B, 0, 0);
 	// systemSetInt(INTB_AUD0, 0, 0);
 	// systemSetInt(INTB_AUD1, 0, 0);
 	// systemSetInt(INTB_AUD2, 0, 0);

--- a/src/ace/managers/ptplayer.c
+++ b/src/ace/managers/ptplayer.c
@@ -2634,7 +2634,7 @@ tPtplayerMod *ptplayerModCreate(const char *szPath) {
 	else {
 		pMod = memAllocFast(sizeof(*pMod));
 		if(pMod) {
-			pMod->ulSize = fileGetSize(szPath);
+			pMod->ulSize = lSize;
 			pMod->pData = memAllocChip(pMod->ulSize);
 			if(pMod->pData) {
 				tFile *pFileMod = fileOpen(szPath, "rb");


### PR DESCRIPTION
Fixed timer A interrupt cleanup code when using VBL
and slight performance boost when loading MOD (especially from floppy) by not query getFileSize() twice