### PR TITLE
Fix for AGA depth modes, and how long the Copper needs to wait before it does it's magic.

### DIFF
--- a/include/ace/generic/screen.h
+++ b/include/ace/generic/screen.h
@@ -20,6 +20,25 @@ extern "C" {
 #define SCREEN_NTSC_HIRES_WIDTH 640
 #define SCREEN_HTSC_LACED_HEIGHT 400
 
+
+// For EHB screens to work properly, Copper has to wait for the line before
+// the actual display starts and change the regs in horizontal blanking.
+// Positions 0xD0, 0xD8, 0xE0 work, but 0xE2 doesn't - use the last valid copper
+// wait pos so that the regs are ready just before the display - user stuff
+// must go prior this wait pos!
+// 0xE0 didn't work for me in simplebuffer though - use 0xDC for safety.
+// TODO: some ppl might want to have the display set up as soon as possible
+// (probably could be done earlier than 0xD0) and then e.g. start changing
+// palette colors before display + right after bitplanes get displayed.
+// Maybe add the switch for this behavior?
+// TODO: right now wait pos is hardcoded for EHB since it's the toughest one
+// KaiN has needed. Add a calculation on proper wait pos (less BPP - later).
+
+// Vairn: AGA modes seem to need a smaller value than EHB, but the value which used to work.
+//  The original value of 0xe2-(7*4), worked for the AGA modes, which equates out to 0xC6, so I'll set it to that for 7bpp and 8bpp. 
+// TODO: Test and find the most optional values.
+// TODO: Figure out if this is more related to fetchmodes for AGA. 
+static s_pCopperWaitXByBitplanes[8] = {0xDC, 0xDC, 0xDC, 0xDC, 0xDC, 0xDC, 0xC6, 0xC6};
 #ifdef __cplusplus
 }
 #endif

--- a/include/ace/generic/screen.h
+++ b/include/ace/generic/screen.h
@@ -38,7 +38,7 @@ extern "C" {
 //  The original value of 0xe2-(7*4), worked for the AGA modes, which equates out to 0xC6, so I'll set it to that for 7bpp and 8bpp. 
 // TODO: Test and find the most optional values.
 // TODO: Figure out if this is more related to fetchmodes for AGA. 
-static s_pCopperWaitXByBitplanes[8] = {0xDC, 0xDC, 0xDC, 0xDC, 0xDC, 0xDC, 0xC6, 0xC6};
+const static s_pCopperWaitXByBitplanes[8] = {0xDC, 0xDC, 0xDC, 0xDC, 0xDC, 0xDC, 0xC6, 0xC6};
 
 #ifdef __cplusplus
 }

--- a/include/ace/generic/screen.h
+++ b/include/ace/generic/screen.h
@@ -8,6 +8,9 @@
 #ifdef __cplusplus
 extern "C" {
 #endif
+
+#include <ace/types.h>
+
 #define SCREEN_PAL_YOFFSET 0x2C
 #define SCREEN_PAL_WIDTH 320
 #define SCREEN_PAL_HEIGHT 256
@@ -38,7 +41,7 @@ extern "C" {
 //  The original value of 0xe2-(7*4), worked for the AGA modes, which equates out to 0xC6, so I'll set it to that for 7bpp and 8bpp. 
 // TODO: Test and find the most optional values.
 // TODO: Figure out if this is more related to fetchmodes for AGA. 
-const static s_pCopperWaitXByBitplanes[8] = {0xDC, 0xDC, 0xDC, 0xDC, 0xDC, 0xDC, 0xC6, 0xC6};
+static const UWORD s_pCopperWaitXByBitplanes[8] = {0xDC, 0xDC, 0xDC, 0xDC, 0xDC, 0xDC, 0xC6, 0xC6};
 
 #ifdef __cplusplus
 }

--- a/include/ace/generic/screen.h
+++ b/include/ace/generic/screen.h
@@ -39,6 +39,7 @@ extern "C" {
 // TODO: Test and find the most optional values.
 // TODO: Figure out if this is more related to fetchmodes for AGA. 
 static s_pCopperWaitXByBitplanes[8] = {0xDC, 0xDC, 0xDC, 0xDC, 0xDC, 0xDC, 0xC6, 0xC6};
+
 #ifdef __cplusplus
 }
 #endif

--- a/src/ace/managers/viewport/scrollbuffer.c
+++ b/src/ace/managers/viewport/scrollbuffer.c
@@ -4,23 +4,10 @@
 
 #include <ace/managers/viewport/scrollbuffer.h>
 #include <ace/utils/tag.h>
+#include <ace/generic/screen.h> // Has the look up table for the COPPER_X_WAIT values.
 #include <limits.h>
 
 #ifdef AMIGA
-
-// For EHB screens to work properly, Copper has to wait for the line before
-// the actual display starts and change the regs in horizontal blanking.
-// Positions 0xD0, 0xD8, 0xE0 work, but 0xE2 doesn't - use the last valid copper
-// wait pos so that the regs are ready just before the display - user stuff
-// must go prior this wait pos!
-// 0xE0 didn't work for me in simplebuffer though - use 0xDC for safety.
-// TODO: some ppl might want to have the display set up as soon as possible
-// (probably could be done earlier than 0xD0) and then e.g. start changing
-// palette colors before display + right after bitplanes get displayed.
-// Maybe add the switch for this behavior?
-// TODO: right now wait pos is hardcoded for EHB since it's the toughest one
-// KaiN has needed. Add a calculation on proper wait pos (less BPP - later).
-#define COPPER_WAIT_X 0xDC
 
 static UWORD nearestPowerOf2(UWORD uwVal) {
 	// https://graphics.stanford.edu/~seander/bithacks.html#RoundUpPowerOf2
@@ -93,7 +80,7 @@ tScrollBufferManager *scrollBufferCreate(void *pTags, ...) {
 			pVPort->pView->pCopList, 2 * pVPort->ubBPP + 8,
 			// Vertically addition from DiWStrt, horizontally just so that 6bpp can be set up.
 			// First to set are ddf, modulos & shift so they are changed during fetch.
-			COPPER_WAIT_X, pVPort->uwOffsY + pVPort->pView->ubPosY -1
+			s_pCopperWaitXByBitplanes[pVPort->ubBPP], pVPort->uwOffsY + pVPort->pView->ubPosY -1
 		);
 		pManager->pBreakBlock = copBlockCreate(
 			pVPort->pView->pCopList, 2 * pVPort->ubBPP + 2,
@@ -207,7 +194,7 @@ UBYTE scrollBufferGetRawCopperlistInstructionCountBreak(UBYTE ubBpp) {
 
 static void resetStartCopperlist(tCopCmd *pCmds, const UWORD uwOffsY, const UBYTE ubBPP, const UWORD uwModulo) {
 	UBYTE i = 0;
-	copSetWait(&pCmds[i++].sWait, COPPER_WAIT_X, uwOffsY);
+	copSetWait(&pCmds[i++].sWait, s_pCopperWaitXByBitplanes[ubBPP], uwOffsY);
 	// prepare bitplane ptrs & bplcon commands. will be updated in process
 	copSetMove(&pCmds[i++].sMove, &g_pCustom->bplcon1, 0);
 	for(UBYTE j = 0; j < ubBPP; j++) {
@@ -325,7 +312,7 @@ void scrollBufferProcess(tScrollBufferManager *pManager) {
 			if(pBlock->ubDisabled) {
 				copBlockEnable(pCopList, pBlock);
 			}
-			copBlockWait(pCopList, pBlock, COPPER_WAIT_X, (
+			copBlockWait(pCopList, pBlock, s_pCopperWaitXByBitplanes[pManager->sCommon.pVPort->ubBPP], (
 				pManager->sCommon.pVPort->pView->ubPosY +
 				pManager->sCommon.pVPort->uwOffsY +
 				pManager->uwBmAvailHeight - uwScrollY - 1
@@ -426,7 +413,7 @@ void scrollBufferReset(
 	else {
 		tCopBlock *pBlock = pManager->pStartBlock;
 		// Set initial WAIT
-		copBlockWait(pCopList, pBlock, COPPER_WAIT_X, (
+		copBlockWait(pCopList, pBlock, s_pCopperWaitXByBitplanes[pManager->sCommon.pVPort->ubBPP], (
 			pManager->sCommon.pVPort->pView->ubPosY +
 			pManager->sCommon.pVPort->uwOffsY - 1
 		));

--- a/src/ace/managers/viewport/simplebuffer.c
+++ b/src/ace/managers/viewport/simplebuffer.c
@@ -6,11 +6,9 @@
 #include <proto/exec.h>
 #include <ace/utils/tag.h>
 #include <ace/utils/extview.h>
-
+#include <ace/generic/screen.h> // Has the look up table for the COPPER_X_WAIT values.
 #ifdef AMIGA
 
-// 0xDC is sufficient wait pos for EHB to be ready just before bitplane display.
-#define COPPER_WAIT_X 0xDC
 
 // Flags for internal usage.
 #define SIMPLEBUFFER_FLAG_X_SCROLLABLE 1
@@ -66,7 +64,7 @@ static void simpleBufferInitializeCopperList(
 			"Setting copperlist %p at offs %u\n",
 			pCopList->pBackBfr, pManager->uwCopperOffset
 		);
-		copSetWait(&pCmdList[0].sWait, COPPER_WAIT_X, (
+		copSetWait(&pCmdList[0].sWait, s_pCopperWaitXByBitplanes[pManager->sCommon.pVPort->ubBPP], (
 			pManager->sCommon.pVPort->uwOffsY +
 			pManager->sCommon.pVPort->pView->ubPosY -1
 		));
@@ -209,7 +207,8 @@ tSimpleBufferManager *simpleBufferCreate(void *pTags, ...) {
 			pCopList, simpleBufferGetRawCopperlistInstructionCount(pVPort->ubBPP) - 1,
 			// Vertically addition from DiWStrt, horizontally just so that 6bpp can be set up.
 			// First to set are ddf, modulos & shift so they are changed during fetch.
-			COPPER_WAIT_X, pVPort->uwOffsY + pVPort->pView->ubPosY - 1
+			s_pCopperWaitXByBitplanes[pVPort->ubBPP],
+			 pVPort->uwOffsY + pVPort->pView->ubPosY - 1
 		);
 	}
 	else {


### PR DESCRIPTION
On AGA depth modes, the copper needs a little bit more time to do it's magic, so the Constant value is now a small lookup table.
These values can probably be tweaked a little to make it a bit tighter but it fixes the corruption that I was getting with My AGA Branch of ACE. 