### PR TITLE
Copper x wait fix

### DIFF
--- a/include/ace/generic/screen.h
+++ b/include/ace/generic/screen.h
@@ -41,7 +41,7 @@ extern "C" {
 //  The original value of 0xe2-(7*4), worked for the AGA modes, which equates out to 0xC6, so I'll set it to that for 7bpp and 8bpp. 
 // TODO: Test and find the most optional values.
 // TODO: Figure out if this is more related to fetchmodes for AGA. 
-static const UWORD s_pCopperWaitXByBitplanes[8] = {0x00, 0xDC, 0xDC, 0xDC, 0xDC, 0xDC, 0xDC, 0xC6, 0xC6};
+static const UWORD s_pCopperWaitXByBitplanes[9] = {0x00, 0xDC, 0xDC, 0xDC, 0xDC, 0xDC, 0xDC, 0xC6, 0xC6};
 
 #ifdef __cplusplus
 }

--- a/include/ace/generic/screen.h
+++ b/include/ace/generic/screen.h
@@ -41,7 +41,7 @@ extern "C" {
 //  The original value of 0xe2-(7*4), worked for the AGA modes, which equates out to 0xC6, so I'll set it to that for 7bpp and 8bpp. 
 // TODO: Test and find the most optional values.
 // TODO: Figure out if this is more related to fetchmodes for AGA. 
-static const UWORD s_pCopperWaitXByBitplanes[8] = {0xDC, 0xDC, 0xDC, 0xDC, 0xDC, 0xDC, 0xC6, 0xC6};
+static const UWORD s_pCopperWaitXByBitplanes[8] = {0x00, 0xDC, 0xDC, 0xDC, 0xDC, 0xDC, 0xDC, 0xC6, 0xC6};
 
 #ifdef __cplusplus
 }


### PR DESCRIPTION
You know, sometimes I forget how to count.
Added an extra element to account for that rare 0 bitplanes..

An alternate solution is to subtract 1 from the bpp when doing the lookup but that would mean it is a little less optimized.
 