### PR TITLE
don't check if tile is non-zero since margin redraw code checks for a…

### DIFF
--- a/src/ace/managers/viewport/tilebuffer.c
+++ b/src/ace/managers/viewport/tilebuffer.c
@@ -559,13 +559,11 @@ UBYTE tileBufferIsTileOnBuffer(
 	UWORD uwStartY = MAX(0, (pManager->pCamera->uPos.uwY >> ubTileShift) -1);
 	UWORD uwEndY = uwStartY + ((pManager->uwMarginedHeight >> ubTileShift) - 2);
 
-	if(
-		uwStartX <= uwTileX && uwTileX <= uwEndX && uwTileX &&
-		uwStartY <= uwTileY && uwTileY <= uwEndY && uwTileY
-	) {
-		return 1;
-	}
-	return 0;
+	UBYTE isOnBuffer = (
+		uwStartX <= uwTileX && uwTileX <= uwEndX &&
+		uwStartY <= uwTileY && uwTileY <= uwEndY
+	);
+	return isOnBuffer;
 }
 
 void tileBufferSetTile(


### PR DESCRIPTION
…bove-zero

Hopefully it's not breaking in tilebuffer. If it is, it's lacking documentation about first/last rows/columns being reserved.