### PR TITLE
Pull request templates with self-assesment for new components

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE/minor.md
+++ b/.github/PULL_REQUEST_TEMPLATE/minor.md
@@ -1,0 +1,11 @@
+<!--- Use this only if you've made non-breaking improvements or bugfixes -->
+
+## Description
+<!--- Describe your changes in few words/sentences.  If your pull request is related to an issue, please put `Closes #issueNumber` or `Related to #issueNumber` sentence here -->
+
+## Checklist
+<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
+<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
+- [ ] My code follows the code style of this project.
+- [ ] My change requires a change to the documentation.
+- [ ] I have updated the documentation accordingly.

--- a/.github/PULL_REQUEST_TEMPLATE/new_component.md
+++ b/.github/PULL_REQUEST_TEMPLATE/new_component.md
@@ -1,0 +1,69 @@
+<!--- Use this only if you've created new ACE component (manager, util, etc.). Please provide a name of your newly created ACE component in title of pull request. -->
+
+## Description
+<!--- Describe your changes in few sentences. If your pull request is related to an issue, please put `Closes #issueNumber` or `Related to #issueNumber` sentence here. -->
+
+## Motivation and Context
+<!--- Why is this change required? What problem does it solve? -->
+<!--- If it fixes an open issue, please link to the issue here. -->
+
+## ACE inclusion self-assesment
+<!--- It's most likely that we'll include your code in ACE's codebase anyway, however please take a few minutes to answer following questions, which will allow making more conscious decision. -->
+
+**Are there significantly different solutions to same problem? If so, is it the most common/generic one?**
+
+<!--- Please answer here -->
+
+**Are other solutions better and should ACE incorporate it instead of this change in the long run?**
+
+<!--- Please answer here -->
+
+**Is given functionality needed or nice to have for most of games? Is it used often in tandem with ACE?**
+
+<!--- Please answer here -->
+
+**Is it small/simple enough to not require much maintenance?**
+
+<!--- Please answer here -->
+
+**Is the functionality related to a core Amiga concept?**
+
+<!--- Please answer here -->
+
+**Is it entirely, or its ACE interface, written by core ACE team or frequent contributors?**
+
+<!--- Please answer here -->
+
+**Is it a building block or dependency for other parts of code? How much coupling there is between this part and rest of ACE code?**
+
+<!--- Please answer here -->
+
+**Does it allow making significantly better games at reasonable performance cost?**
+
+<!--- Please answer here -->
+
+**Is most of the code first-party?**
+
+<!--- Please answer here -->
+
+**Does it require additions/changes/removal of some other parts of ACE functionality/tooling for its use?**
+
+<!--- Please answer here -->
+
+## How Has This Been Tested?
+<!--- Please describe in detail how you tested your changes. -->
+<!--- Especially point out in which productions it was used so far -->
+
+## Types of changes
+<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
+- [ ] Bug fix (non-breaking change which fixes an issue)
+- [ ] New feature (non-breaking change which adds functionality)
+- [ ] Breaking change (fix or feature that would cause existing functionality to change)
+
+## Checklist
+<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
+<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
+- [ ] My code follows the code style of this project.
+- [ ] My change requires a change to existing documentation.
+- [ ] My change requires a new chapter in documentation's tutorial.
+- [ ] I have updated the documentation accordingly.

--- a/.github/PULL_REQUEST_TEMPLATE/significant_changes.md
+++ b/.github/PULL_REQUEST_TEMPLATE/significant_changes.md
@@ -1,0 +1,25 @@
+<!--- Use this only if you've made significant changes to ACE's inner workings. -->
+
+## Description
+<!--- Describe your changes in few sentences. If your pull request is related to an issue, please put `Closes #issueNumber` or `Related to #issueNumber` sentence here. -->
+
+## Motivation and Context
+<!--- Why is this change required? What problem does it solve? -->
+<!--- If it fixes an open issue, please link to the issue here. -->
+
+## How Has This Been Tested?
+<!--- Please describe in detail how you tested your changes. -->
+<!--- Especially point out in which productions it was used so far -->
+
+## Types of changes
+<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
+- [ ] Bug fix (non-breaking change which fixes an issue)
+- [ ] New feature (non-breaking change which adds functionality)
+- [ ] Breaking change (fix or feature that would cause existing functionality to change)
+
+## Checklist
+<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
+<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
+- [ ] My code follows the code style of this project.
+- [ ] My change requires a change to the documentation.
+- [ ] I have updated the documentation accordingly.

--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,0 +1,5 @@
+Please go the the `Preview` tab and select the appropriate sub-template:
+
+* [New component](?expand=1&template=new_component.md)
+* [Significant changes](?expand=1&template=significant_changes.md)
+* [Small and non-breaking improvements or bugfixes](?expand=1&template=minor.md)


### PR DESCRIPTION
Closes #189, I think.

Adds three PR templates:

- for small contributions (simplest one)
- for major changes (fields for rationale etc.)
- for new components (rationale, self-assessment of inclusion to ACE)

and also a generic pull request template which works as PR template selection, as suggested on https://stackoverflow.com/questions/73771068/multiple-templates-for-pull-requests-on-github

I'll leave it dangling for a day or two. All reviews are welcome! If no one opposes, I'll merge it and try to put bob manager through it in separate PR.