### PR TITLE
font_conv: fix trimming ttf fonts

### DIFF
--- a/tools/src/common/glyph_set.cpp
+++ b/tools/src/common/glyph_set.cpp
@@ -320,8 +320,8 @@ void tGlyphSet::tBitmapGlyph::trimHorz(bool isRight)
 	uint8_t ubNewStart;
 	if(isRight) {
 		ubNewStart = 0;
-		for(ubNewWidth = m_ubWidth - 1; ubNewWidth > 0; --ubNewWidth) {
-			if(!hasEmptyColumn(ubNewWidth)) {
+		for(ubNewWidth = m_ubWidth; ubNewWidth > 0; --ubNewWidth) {
+			if(!hasEmptyColumn(ubNewWidth - 1)) {
 				break;
 			}
 		}

--- a/tools/src/common/glyph_set.cpp
+++ b/tools/src/common/glyph_set.cpp
@@ -34,15 +34,15 @@ tGlyphSet tGlyphSet::fromPmng(const std::string &szPngPath, uint8_t ubStartIdx)
 			uint16_t uwStop = i;
 
 			tGlyphSet::tBitmapGlyph Glyph;
-			Glyph.ubWidth = (uwStop - uwStart) - 1;
-			Glyph.ubHeight = Bitmap.m_uwHeight;
-			Glyph.ubBearing = 0;
-			Glyph.vData.reserve(Glyph.ubWidth * Glyph.ubHeight);
+			Glyph.m_ubWidth = (uwStop - uwStart) - 1;
+			Glyph.m_ubHeight = Bitmap.m_uwHeight;
+			Glyph.m_ubBearing = 0;
+			Glyph.m_vData.reserve(Glyph.m_ubWidth * Glyph.m_ubHeight);
 
 			for(uint16_t y = 0; y < Bitmap.m_uwHeight; ++y) {
 				for(uint16_t x = uwStart + 1; x < uwStop; ++x) {
 					const auto &Pixel = Bitmap.pixelAt(x, y);
-					Glyph.vData.push_back((Pixel == Bg ? 0 : 0xFF));
+					Glyph.m_vData.push_back((Pixel == Bg ? 0 : 0xFF));
 				}
 			}
 			GlyphSet.m_mGlyphs.insert(std::make_pair(uwCurrChar, Glyph));
@@ -102,16 +102,16 @@ tGlyphSet tGlyphSet::fromAceFont(const std::string &szFntPath)
 		uint8_t ubGlyphWidth = vCharOffsets[c + 1] - vCharOffsets[c];
 		if(ubGlyphWidth) {
 			tBitmapGlyph Glyph;
-			Glyph.vData.resize(uwBitmapHeight * ubGlyphWidth);
+			Glyph.m_vData.resize(uwBitmapHeight * ubGlyphWidth);
 			for(uint8_t ubY = 0; ubY < uwBitmapHeight; ++ubY) {
 				for(uint8_t ubX = 0; ubX < ubGlyphWidth; ++ubX) {
 					// Since filled in Chunky is (FF,FF,FF), use data from any channel.
-					Glyph.vData[ubY * ubGlyphWidth + ubX] = Chunky.pixelAt(vCharOffsets[c] + ubX, ubY).ubR;
+					Glyph.m_vData[ubY * ubGlyphWidth + ubX] = Chunky.pixelAt(vCharOffsets[c] + ubX, ubY).ubR;
 				}
 			}
-			Glyph.ubWidth =  ubGlyphWidth;
-			Glyph.ubHeight = uwBitmapHeight;
-			Glyph.ubBearing = 0;
+			Glyph.m_ubWidth =  ubGlyphWidth;
+			Glyph.m_ubHeight = uwBitmapHeight;
+			Glyph.m_ubBearing = 0;
 			GlyphSet.m_mGlyphs.emplace(std::make_pair(c, std::move(Glyph)));
 		}
 	}
@@ -164,9 +164,9 @@ tGlyphSet tGlyphSet::fromTtf(
 		auto &Glyph = GlyphSet.m_mGlyphs[ulCodepoint];
 
 		// Copy bitmap graphics with threshold
-		for(uint32_t ulPos = 0; ulPos < GlyphSet.m_mGlyphs[c].vData.size(); ++ulPos) {
+		for(uint32_t ulPos = 0; ulPos < Glyph.m_vData.size(); ++ulPos) {
 			uint8_t ubVal = (Face->glyph->bitmap.buffer[ulPos] >= ubThreshold) ? 0xFF : 0;
-			GlyphSet.m_mGlyphs[c].vData[ulPos] = ubVal;
+			Glyph.m_vData[ulPos] = ubVal;
 		}
 
 		// Trim left & right
@@ -176,13 +176,13 @@ tGlyphSet tGlyphSet::fromTtf(
 		}
 		else {
 			// At least write proper width
-			Glyph.ubWidth = Face->glyph->metrics.horiAdvance / 64;
+			Glyph.m_ubWidth = Face->glyph->metrics.horiAdvance / 64;
 		}
 
-		ubMaxBearing = std::max(ubMaxBearing, Glyph.ubBearing);
+		ubMaxBearing = std::max(ubMaxBearing, Glyph.m_ubBearing);
 		ubMaxAddHeight = std::max(
 			ubMaxAddHeight,
-			static_cast<uint8_t>(std::max(0, Glyph.ubHeight - Glyph.ubBearing))
+			static_cast<uint8_t>(std::max(0, Glyph.m_ubHeight - Glyph.m_ubBearing))
 		);
 	}
 	FT_Done_Face(Face);
@@ -193,13 +193,13 @@ tGlyphSet tGlyphSet::fromTtf(
 	// Normalize Glyph height
 	for(auto &GlyphPair: GlyphSet.m_mGlyphs) {
 		auto &Glyph = GlyphPair.second;
-		std::vector<uint8_t> vNewData(Glyph.ubWidth * ubBmHeight, 0);
-		auto Dst = vNewData.begin() + Glyph.ubWidth * (ubMaxBearing - Glyph.ubBearing);
-		for(auto Src = Glyph.vData.begin(); Src != Glyph.vData.end(); ++Src, ++Dst) {
+		std::vector<uint8_t> vNewData(Glyph.m_ubWidth * ubBmHeight, 0);
+		auto Dst = vNewData.begin() + Glyph.m_ubWidth * (ubMaxBearing - Glyph.m_ubBearing);
+		for(auto Src = Glyph.m_vData.begin(); Src != Glyph.m_vData.end(); ++Src, ++Dst) {
 			*Dst = *Src;
 		}
-		Glyph.vData = vNewData;
-		Glyph.ubHeight = ubBmHeight;
+		Glyph.m_vData = vNewData;
+		Glyph.m_ubHeight = ubBmHeight;
 	}
 
 	return GlyphSet;
@@ -212,13 +212,13 @@ tGlyphSet tGlyphSet::fromDir(const std::string &szDirPath)
 		auto Chunky = tChunkyBitmap::fromPng(fmt::format("{}/{}.png", szDirPath, c));
 		if(Chunky.m_uwHeight) {
 			tGlyphSet::tBitmapGlyph Glyph;
-			Glyph.ubWidth = Chunky.m_uwWidth;
-			Glyph.ubHeight = Chunky.m_uwHeight;
-			Glyph.ubBearing = 0;
-			Glyph.vData.reserve(Glyph.ubWidth * Glyph.ubHeight);
+			Glyph.m_ubWidth = Chunky.m_uwWidth;
+			Glyph.m_ubHeight = Chunky.m_uwHeight;
+			Glyph.m_ubBearing = 0;
+			Glyph.m_vData.reserve(Glyph.m_ubWidth * Glyph.m_ubHeight);
 			// It's sufficient to base on R channel
 			for(const auto &Pixel: Chunky.m_vData) {
-				Glyph.vData.push_back(Pixel.ubR ? 0xFF : 0x00);
+				Glyph.m_vData.push_back(Pixel.ubR ? 0xFF : 0x00);
 			}
 			GlyphSet.m_mGlyphs.emplace(std::make_pair(c, std::move(Glyph)));
 		}
@@ -231,19 +231,19 @@ bool tGlyphSet::toDir(const std::string &szDirPath)
 	nFs::dirCreate(szDirPath);
 	for(const auto &GlyphPair: m_mGlyphs) {
 		auto Glyph = GlyphPair.second;
-		std::vector<tRgb> vImage(Glyph.ubWidth * Glyph.ubHeight, tRgb(0));
+		std::vector<tRgb> vImage(Glyph.m_ubWidth * Glyph.m_ubHeight, tRgb(0));
 
-		for(auto y = 0; y < Glyph.ubHeight; ++y) {
-			for(auto x = 0; x < Glyph.ubWidth; ++x) {
-				auto Val = Glyph.vData[y * Glyph.ubWidth + x];
-				vImage[y * Glyph.ubWidth + x] = tRgb(Val);
+		for(auto y = 0; y < Glyph.m_ubHeight; ++y) {
+			for(auto x = 0; x < Glyph.m_ubWidth; ++x) {
+				auto Val = Glyph.m_vData[y * Glyph.m_ubWidth + x];
+				vImage[y * Glyph.m_ubWidth + x] = tRgb(Val);
 			}
 		}
 
 		auto LodeErr = lodepng_encode_file(
 			fmt::format("{}/{}.png", szDirPath, static_cast<unsigned char>(GlyphPair.first)).c_str(),
 			reinterpret_cast<uint8_t*>(vImage.data()),
-			Glyph.ubWidth, Glyph.ubHeight, LCT_RGB, 8
+			Glyph.m_ubWidth, Glyph.m_ubHeight, LCT_RGB, 8
 		);
 
 		if(LodeErr) {
@@ -256,12 +256,12 @@ bool tGlyphSet::toDir(const std::string &szDirPath)
 
 tChunkyBitmap tGlyphSet::toPackedBitmap(bool isPmng)
 {
-	uint8_t ubHeight = m_mGlyphs.begin()->second.ubHeight;
+	uint8_t ubHeight = m_mGlyphs.begin()->second.m_ubHeight;
 
 	// Calculate total width & round up to multiple of 16
 	uint16_t uwWidth = 0;
 	for(const auto &[Key, Glyph]: m_mGlyphs) {
-		uwWidth += Glyph.ubWidth + (isPmng ? 1 : 0);
+		uwWidth += Glyph.m_ubWidth + (isPmng ? 1 : 0);
 	}
 	uwWidth = ((uwWidth + 15) / 16) * 16;
 
@@ -273,50 +273,76 @@ tChunkyBitmap tGlyphSet::toPackedBitmap(bool isPmng)
 			Chunky.pixelAt(uwOffsX, 0) = tRgb(0xFF, 0, 0);
 			uwOffsX += 1;
 		}
-		for(auto y = 0; y < Glyph.ubHeight; ++y) {
-			for(auto x = 0; x < Glyph.ubWidth; ++x) {
-				auto Val = Glyph.vData[y * Glyph.ubWidth + x];
+		for(auto y = 0; y < Glyph.m_ubHeight; ++y) {
+			for(auto x = 0; x < Glyph.m_ubWidth; ++x) {
+				auto Val = Glyph.m_vData[y * Glyph.m_ubWidth + x];
 				Chunky.pixelAt(uwOffsX + x, y) = tRgb(Val);
 			}
 		}
-		uwOffsX += Glyph.ubWidth;
+		uwOffsX += Glyph.m_ubWidth;
 	}
 	return Chunky;
 }
 
+uint8_t tGlyphSet::tBitmapGlyph::getValueAt(uint8_t ubX, uint8_t ubY)
+{
+	uint8_t ubValue = this->m_vData[ubY * this->m_ubWidth + ubY];
+	return ubValue;
+}
+
+bool tGlyphSet::tBitmapGlyph::hasEmptyColumn(uint8_t ubX)
+{
+	for(uint8_t ubY = 0; ubY < this->m_ubHeight; ++ubY) {
+		if(getValueAt(ubX, ubY) != 0) {
+			return false;
+		}
+	}
+	return true;
+}
+
+bool tGlyphSet::tBitmapGlyph::isEmpty(void)
+{
+	for(uint8_t ubX = 0; ubX < this->m_ubWidth; ++ubX) {
+		if(!hasEmptyColumn(ubX)) {
+			return false;
+		}
+	}
+	return true;
+}
+
 void tGlyphSet::tBitmapGlyph::trimHorz(bool isRight)
 {
-	uint8_t ubHeight = this->ubHeight;
-	if(ubHeight == 0) {
+	if(isEmpty()) {
 		return;
 	}
-	bool isTrimmable = true;
-	while(isTrimmable) {
-		uint8_t ubWidth = this->ubWidth;
-		uint8_t ubDx = 0;
-		uint8_t ubStartX = 1;
-		if(isRight) {
-			ubDx = ubWidth - 1;
-			ubStartX = 0;
-		}
 
-		for(uint8_t y = 0; y < ubHeight; ++y) {
-			if(this->vData[y * ubWidth + ubDx] != 0xFF) {
-				isTrimmable = false;
+	uint8_t ubNewWidth;
+	uint8_t ubNewStart;
+	if(isRight) {
+		ubNewStart = 0;
+		for(ubNewWidth = m_ubWidth - 1; ubNewWidth > 0; --ubNewWidth) {
+			if(!hasEmptyColumn(ubNewWidth)) {
 				break;
 			}
 		}
-		if(isTrimmable) {
-			std::vector<uint8_t> vNew((ubWidth - 1) * ubHeight);
-			for(uint8_t x = 0; x < ubWidth-1; ++x) {
-				for(uint8_t y = 0; y < ubHeight; ++y) {
-					vNew[y * (ubWidth - 1) + x] = this->vData[y * ubWidth + ubStartX + x];
-				}
+	}
+	else {
+		for(ubNewStart = 0; ubNewStart < m_ubWidth; ++ubNewStart) {
+			if(!hasEmptyColumn(ubNewStart)) {
+				break;
 			}
-			this->vData = vNew;
-			--this->ubWidth;
+		}
+		ubNewWidth = m_ubWidth - ubNewStart;
+	}
+
+	std::vector<uint8_t> vNew(ubNewWidth * m_ubHeight);
+	for(uint8_t ubNewX = 0; ubNewX < ubNewWidth; ++ubNewX) {
+		for(uint8_t ubNewY = 0; ubNewY < m_ubHeight; ++ubNewY) {
+			vNew[ubNewY * ubNewWidth + ubNewX] = this->m_vData[ubNewY * m_ubWidth + ubNewStart + ubNewX];
 		}
 	}
+	m_vData = vNew;
+	m_ubWidth = ubNewWidth;
 }
 
 void tGlyphSet::toAceFont(const std::string &szFontPath)
@@ -335,7 +361,7 @@ void tGlyphSet::toAceFont(const std::string &szFontPath)
 		vCharOffsets[c] = nEndian::toBig16(uwOffs);
 		if(m_mGlyphs.count(c) != 0) {
 			const auto &Glyph = m_mGlyphs.at(c);
-			uwOffs += Glyph.ubWidth;
+			uwOffs += Glyph.m_ubWidth;
 		}
 	}
 	// This allows drawing of last char
@@ -350,7 +376,7 @@ void tGlyphSet::toAceFont(const std::string &szFontPath)
 	// Write header
 	uint16_t uwBitmapWidth = nEndian::toBig16(Planar.m_uwWidth);
 	Out.write(reinterpret_cast<char*>(&uwBitmapWidth), sizeof(uint16_t));
-	uint16_t uwBitmapHeight = nEndian::toBig16(m_mGlyphs.begin()->second.ubHeight);
+	uint16_t uwBitmapHeight = nEndian::toBig16(m_mGlyphs.begin()->second.m_ubHeight);
 	Out.write(reinterpret_cast<char*>(&uwBitmapHeight), sizeof(uint16_t));
 	Out.write(reinterpret_cast<char*>(&ubCharCount), sizeof(uint8_t));
 

--- a/tools/src/common/glyph_set.h
+++ b/tools/src/common/glyph_set.h
@@ -48,11 +48,15 @@ public:
 
 private:
 	struct tBitmapGlyph {
-		uint8_t ubBearing;
-		uint8_t ubWidth, ubHeight;
-		std::vector<uint8_t> vData; ///< One byte per pixel, 0 for bg, 0xFF otherwise.
+		uint8_t m_ubBearing;
+		uint8_t m_ubWidth, m_ubHeight;
+		std::vector<uint8_t> m_vData; ///< One byte per pixel, 0 for bg, 0xFF otherwise.
 
 		void trimHorz(bool isRight);
+
+		uint8_t getValueAt(uint8_t ubX, uint8_t ubY);
+		bool isEmpty(void);
+		bool hasEmptyColumn(uint8_t ubX);
 	};
 
 	std::map<uint16_t, tBitmapGlyph> m_mGlyphs;


### PR DESCRIPTION
<!--- Use this only if you've made non-breaking improvements or bugfixes -->

## Description
Fixes the algorithm for trimming empty space around ttf font glyphs.
Closes #201
Closes #202 

## Checklist
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
