### PR TITLE
remove stateCreate()'s pPrev param

### DIFF
--- a/docs/programming/hello_world.md
+++ b/docs/programming/hello_world.md
@@ -197,7 +197,7 @@ void genericCreate(void) {
   keyCreate(); // We'll use keyboard
   // Initialize gamestate
   g_pGameStateManager = stateManagerCreate();
-  g_pGameState = stateCreate(gameGsCreate, gameGsLoop, gameGsDestroy, 0, 0, 0);
+  g_pGameState = stateCreate(gameGsCreate, gameGsLoop, gameGsDestroy, 0, 0);
 
   statePush(g_pGameStateManager, g_pGameState);
 }

--- a/include/ace/managers/state.h
+++ b/include/ace/managers/state.h
@@ -55,7 +55,7 @@ tStateManager *stateManagerCreate(void);
 
 /**
  * Cleans up after state manager.
- * @param pStateManager: Pointer to state manager previously created 
+ * @param pStateManager: Pointer to state manager previously created
  *        with stateManagerCreate.
  * @see stateManagerCreate()
  */
@@ -68,13 +68,11 @@ void stateManagerDestroy(tStateManager *pStateManager);
  * @param cbDestroy: Callback that fires when state manager exists from this state.
  * @param cbSuspend: Callback that fires when state manager pushes new state over this state.
  * @param cbResume: Callback that fires when state manager pops old state over this state.
- * @param pPrev: Pointer to previous state. Zero if there is no previous state.
  * @see stateDestroy()
  */
 tState *stateCreate(
 	tStateCb cbCreate, tStateCb cbLoop, tStateCb cbDestroy,
-	tStateCb cbSuspend, tStateCb cbResume,
-	tState *pPrev
+	tStateCb cbSuspend, tStateCb cbResume
 );
 
 /**
@@ -86,7 +84,7 @@ void stateDestroy(tState *pState);
 
 /**
  * Pushes given state over current state in given state manager. Calls cbSuspend
- * on old state and cbCreate on new state. Will update pPrev in given state to 
+ * on old state and cbCreate on new state. Will update pPrev in given state to
  * point the old one.
  * @param pStateManager: Pointer to desired state manager where push will happen.
  * @param pState: Pointer to desired state which will be pushed.
@@ -107,7 +105,7 @@ void statePush(tStateManager *pStateManager, tState *pState);
 void statePop(tStateManager *pStateManager);
 
 /**
- * Pops all states from given state manager. Calls cbDestroy on all states 
+ * Pops all states from given state manager. Calls cbDestroy on all states
  * when sets pCurrent to zero.
  * @param pStateManager: Pointer to desired state manager where pop will happen.
  * @see statePop()

--- a/showcase/src/game.c
+++ b/showcase/src/game.c
@@ -45,15 +45,15 @@ void genericDestroy(void) {
 
 void createGameStates(void) {
     g_pGameStateManager = stateManagerCreate();
-    
-    g_pGameStates[GAME_STATE_MENU] = stateCreate(gsMenuCreate, gsMenuLoop, gsMenuDestroy, 0, 0, 0);
-    g_pGameStates[GAME_STATE_BLIT] = stateCreate(gsTestBlitCreate, gsTestBlitLoop, gsTestBlitDestroy, 0, 0, 0);
-    g_pGameStates[GAME_STATE_FONT] = stateCreate(gsTestFontCreate, gsTestFontTableLoop, gsTestFontDestroy, 0, 0, 0);
-    g_pGameStates[GAME_STATE_COPPER] = stateCreate(gsTestCopperCreate, gsTestCopperLoop, gsTestCopperDestroy, 0, 0, 0);
-    g_pGameStates[GAME_STATE_LINES] = stateCreate(gsTestLinesCreate, gsTestLinesLoop, gsTestLinesDestroy, 0, 0, 0);
-    g_pGameStates[GAME_STATE_BLIT_SMALL_DEST] = stateCreate(gsTestBlitSmallDestCreate, gsTestBlitSmallDestLoop, gsTestBlitSmallDestDestroy, 0, 0, 0);
-    g_pGameStates[GAME_STATE_INTERLEAVED] = stateCreate(gsTestInterleavedCreate, gsTestInterleavedLoop, gsTestInterleavedDestroy, 0, 0, 0);
-    g_pGameStates[GAME_STATE_BUFFER_SCROLL] = stateCreate(gsTestBufferScrollCreate, gsTestBufferScrollLoop, gsTestBufferScrollDestroy, 0, 0, 0);
+
+    g_pGameStates[GAME_STATE_MENU] = stateCreate(gsMenuCreate, gsMenuLoop, gsMenuDestroy, 0, 0);
+    g_pGameStates[GAME_STATE_BLIT] = stateCreate(gsTestBlitCreate, gsTestBlitLoop, gsTestBlitDestroy, 0, 0);
+    g_pGameStates[GAME_STATE_FONT] = stateCreate(gsTestFontCreate, gsTestFontTableLoop, gsTestFontDestroy, 0, 0);
+    g_pGameStates[GAME_STATE_COPPER] = stateCreate(gsTestCopperCreate, gsTestCopperLoop, gsTestCopperDestroy, 0, 0);
+    g_pGameStates[GAME_STATE_LINES] = stateCreate(gsTestLinesCreate, gsTestLinesLoop, gsTestLinesDestroy, 0, 0);
+    g_pGameStates[GAME_STATE_BLIT_SMALL_DEST] = stateCreate(gsTestBlitSmallDestCreate, gsTestBlitSmallDestLoop, gsTestBlitSmallDestDestroy, 0, 0);
+    g_pGameStates[GAME_STATE_INTERLEAVED] = stateCreate(gsTestInterleavedCreate, gsTestInterleavedLoop, gsTestInterleavedDestroy, 0, 0);
+    g_pGameStates[GAME_STATE_BUFFER_SCROLL] = stateCreate(gsTestBufferScrollCreate, gsTestBufferScrollLoop, gsTestBufferScrollDestroy, 0, 0);
 }
 
 void destroyGameStates(void) {

--- a/src/ace/managers/state.c
+++ b/src/ace/managers/state.c
@@ -49,12 +49,11 @@ void stateManagerDestroy(tStateManager *pStateManager) {
 
 tState *stateCreate(
 	tStateCb cbCreate, tStateCb cbLoop, tStateCb cbDestroy,
-	tStateCb cbSuspend, tStateCb cbResume,
-	tState *pPrev
+	tStateCb cbSuspend, tStateCb cbResume
 ) {
 	logBlockBegin(
-		"stateCreate(cbCreate: %p, cbLoop: %p, cbDestroy: %p, cbSuspend: %p, cbResume: %p, pPrev: %p)",
-		cbCreate, cbLoop, cbDestroy, cbSuspend, cbResume, pPrev
+		"stateCreate(cbCreate: %p, cbLoop: %p, cbDestroy: %p, cbSuspend: %p, cbResume: %p)",
+		cbCreate, cbLoop, cbDestroy, cbSuspend, cbResume
 	);
 
 	tState *pState = memAllocFast(sizeof(tState));
@@ -64,7 +63,7 @@ tState *stateCreate(
 	pState->cbDestroy = cbDestroy;
 	pState->cbSuspend = cbSuspend;
 	pState->cbResume = cbResume;
-	pState->pPrev = pPrev;
+	pState->pPrev = 0;
 
 	logBlockEnd("stateCreate()");
 


### PR DESCRIPTION
<!--- Use this only if you've made non-breaking improvements or bugfixes -->

## Description
Makes the stateCreate() function use more straightforward and less error-prone.
The pPrev field has strictly internal functionality and shouldn't be exposed to (first-time) user.
Manually tampering with it, if ever useful, is considered an advanced use, requiring good knowledge of state manager's internals.

## Checklist
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [x] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.
