### PR TITLE
Update tools.md instructions for MacOS

### DIFF
--- a/docs/installing/tools.md
+++ b/docs/installing/tools.md
@@ -12,7 +12,11 @@ To build your tools, open the terminal, navigate to ACE's `tools` directory, and
 ```shell
 mkdir build && cd build
 
-# When using GCC on Linux or MSVC on Windows:
+# When using MacOS (to avoid Clang) - assuming you have: brew install gcc@13
+export CC=/usr/local/bin/gcc-13
+export CXX=/usr/local/bin/g++-13
+
+# When using GCC on Linux, MacOS or MSVC on Windows:
 cmake ..
 # When using MinGW GCC on Windows:
 cmake .. -G "MinGW Makefiles"


### PR DESCRIPTION
## Description
Out of the box you can't build tools on a Mac. These instructions are a bit transient on purpose since lots of people use a Mac to compile for native Mac/iOS which assumes Clang. If not, you might want to set your system up to always use GCC (or use something like `CMAKE_USER_MAKE_RULES_OVERRIDE` 🤔).

## Checklist
[ ] My code follows the code style of this project.
[x] My change requires a change to the documentation.
[x] I have updated the documentation accordingly.
