### PR TITLE
Extract memLogPeak() into function

### DIFF
--- a/include/ace/managers/memory.h
+++ b/include/ace/managers/memory.h
@@ -65,6 +65,7 @@ void _memCheckIntegrity(UWORD uwLine, const char *szFile);
 # define memDestroy() _memDestroy()
 # define memCheckTrashAtAddr(pAddr) _memCheckTrashAtAddr(pAddr, __LINE__, __FILE__)
 # define memCheckIntegrity() _memCheckIntegrity(__LINE__, __FILE__)
+# define memLogPeak() _memLogPeak()
 #else
 # define memAlloc(ulSize, ulFlags) _memAllocRls(ulSize, ulFlags)
 # define memFree(pMem, ulSize) _memFreeRls(pMem, ulSize)
@@ -72,6 +73,7 @@ void _memCheckIntegrity(UWORD uwLine, const char *szFile);
 # define memDestroy()
 # define memCheckTrashAtAddr(pAddr, ulSize)
 # define memCheckIntegrity()
+# define memLogPeak()
 #endif // ACE_DEBUG
 
 // Shorthands

--- a/src/ace/managers/memory.c
+++ b/src/ace/managers/memory.c
@@ -190,10 +190,7 @@ void *_memAllocDbg(
 			"[MEM] ERR: couldn't allocate %lu bytes! (%s:%u)\n",
 			ulSize, szFile, uwLine
 		);
-		logWrite(
-			"[MEM] Peak usage: CHIP: %lu, FAST: %lu\n",
-			s_ulChipPeakUsage, s_ulFastPeakUsage
-		);
+		memLogPeak();
 #ifdef AMIGA
 		logWrite(
 			"[MEM] Largest available chunk of given type: %lu\n",
@@ -264,6 +261,13 @@ void _memCheckTrashAtAddr(void *pMem, UWORD uwLine, const char *szFile) {
 		return;
 	}
 	memEntryCheckTrash(pEntry, uwLine, szFile);
+}
+
+void _memLogPeak() {
+	logWrite(
+		"[MEM] Peak usage: CHIP: %lu, FAST: %lu\n",
+		s_ulChipPeakUsage, s_ulFastPeakUsage
+	);
 }
 
 UBYTE memType(const void *pMem) {


### PR DESCRIPTION
## Description
Extract logging of peak CHIP/RAM usage into callable function in memory.c/h for debugging purposes.

## Checklist
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
