### PR TITLE
Add support for interleaved blitcopy

### DIFF
--- a/showcase/CMakeLists.txt
+++ b/showcase/CMakeLists.txt
@@ -23,10 +23,6 @@ file(GLOB_RECURSE HEADERS src/*.h)
 
 include_directories(${PROJECT_SOURCE_DIR}/src)
 
-if(ACE_DEBUG)
-	set(CMAKE_C_FLAGS "${CMAKE_C_FLAGS} -DACE_DEBUG") # For ACE headers with ifdefs
-endif()
-
 set(RES_DIR ${CMAKE_CURRENT_LIST_DIR}/res)
 set(DATA_DIR ${CMAKE_CURRENT_BINARY_DIR}/data)
 

--- a/showcase/src/test/interleaved.c
+++ b/showcase/src/test/interleaved.c
@@ -6,13 +6,23 @@
 #include <ace/utils/extview.h>
 #include <ace/utils/palette.h>
 #include <ace/managers/key.h>
+#include <ace/managers/blit.h>
 #include <ace/managers/system.h>
 #include <ace/managers/viewport/simplebuffer.h>
 #include "game.h"
 
+#define BOUNCE_MARGIN 32
+#define BOUNCE_RECT_WIDTH 32
+#define BOUNCE_RECT_HEIGHT 32
+
 static tView *s_pTestInterleavedView;
 static tVPort *s_pTestInterleavedVPort;
 static tSimpleBufferManager *s_pTestInterleavedBfr;
+static tBitMap *s_pSave;
+static tBitMap *s_pBouncer;
+
+static WORD wX, wY;
+static BYTE bDx, bDy;
 
 void gsTestInterleavedCreate(void) {
 	s_pTestInterleavedView = viewCreate(0,
@@ -36,6 +46,19 @@ void gsTestInterleavedCreate(void) {
 		s_pTestInterleavedBfr->pBack, "data/32c_pal_interleaved.bm", 0, 0
 	);
 
+	s_pSave = bitmapCreate(BOUNCE_RECT_WIDTH + 16, BOUNCE_RECT_HEIGHT, SHOWCASE_BPP, BMF_INTERLEAVED);
+	s_pBouncer = bitmapCreate(BOUNCE_RECT_WIDTH, BOUNCE_RECT_HEIGHT, SHOWCASE_BPP, BMF_INTERLEAVED);
+	blitRect(s_pBouncer, 0, 0, BOUNCE_RECT_WIDTH, BOUNCE_RECT_HEIGHT, 0b10110);
+	wX = 100;
+	wY = 50;
+	bDx = 3;
+	bDy = 1;
+
+	blitCopyAligned(
+		s_pTestInterleavedBfr->pBack, wX & 0xFFF0, wY, s_pSave, 0, 0,
+		BOUNCE_RECT_WIDTH + 16, BOUNCE_RECT_HEIGHT
+	);
+
 	systemUnuse();
 	viewLoad(s_pTestInterleavedView);
 }
@@ -45,9 +68,45 @@ void gsTestInterleavedLoop(void) {
 		stateChange(g_pGameStateManager, &g_pTestStates[TEST_STATE_MENU]);
 		return;
 	}
+
+	blitCopyAligned(
+		s_pSave, 0, 0, s_pTestInterleavedBfr->pBack, wX & 0xFFF0, wY,
+		BOUNCE_RECT_WIDTH + 16, BOUNCE_RECT_HEIGHT
+	);
+	wX += bDx;
+	wY += bDy;
+	if(wX < BOUNCE_MARGIN) {
+		bDx = -bDx;
+		wX = BOUNCE_MARGIN;
+	}
+	if(wY < BOUNCE_MARGIN) {
+		bDy = -bDy;
+		wY = BOUNCE_MARGIN;
+	}
+	if(wX + BOUNCE_RECT_WIDTH >= 320 - BOUNCE_MARGIN) {
+		bDx = -bDx;
+		wX = 320 - BOUNCE_MARGIN - BOUNCE_RECT_WIDTH;
+	}
+	if(wY + BOUNCE_RECT_HEIGHT >= 256 - BOUNCE_MARGIN) {
+		bDy = -bDy;
+		wY = 256 - BOUNCE_MARGIN - BOUNCE_RECT_HEIGHT;
+	}
+	blitCopyAligned(
+		s_pTestInterleavedBfr->pBack, wX & 0xFFF0, wY, s_pSave, 0, 0,
+		BOUNCE_RECT_WIDTH + 16, BOUNCE_RECT_HEIGHT
+	);
+
+	blitCopy(
+		s_pBouncer, 0, 0, s_pTestInterleavedBfr->pBack, wX, wY,
+		BOUNCE_RECT_WIDTH, BOUNCE_RECT_HEIGHT, MINTERM_COOKIE
+	);
+
+	vPortWaitForPos(s_pTestInterleavedVPort, wY + BOUNCE_RECT_HEIGHT, 1);
 }
 
 void gsTestInterleavedDestroy(void) {
 	systemUse();
 	viewDestroy(s_pTestInterleavedView);
+	bitmapDestroy(s_pSave);
+	bitmapDestroy(s_pBouncer);
 }

--- a/showcase/src/test/twister.c
+++ b/showcase/src/test/twister.c
@@ -87,37 +87,24 @@ void gsTestTwisterLoop(void) {
 		stateChange(g_pGameStateManager, &g_pTestStates[TEST_STATE_MENU]);
 		return;
 	}
-
-	if(keyCheck(KEY_UP)) {
-		cameraMoveBy(s_pBfr->pCamera, 0, -1);
-	}
-	if(keyCheck(KEY_DOWN)) {
-		cameraMoveBy(s_pBfr->pCamera, 0, 1);
-	}
-	if(keyCheck(KEY_LEFT)) {
-		cameraMoveBy(s_pBfr->pCamera, -1, 0);
-	}
-	if(keyCheck(KEY_RIGHT)) {
-		cameraMoveBy(s_pBfr->pCamera, 1, 0);
-	}
-	if(keyUse(KEY_R)) {
+	else if(keyUse(KEY_R)) {
 		cameraSetCoord(s_pBfr->pCamera, 0, 0);
 	}
-	if(keyUse(KEY_B)) {
+	else if(keyUse(KEY_B)) {
 		bitmapSaveBmp(s_pBfr->pFront, s_pVPort->pPalette, "twister.bmp");
 	}
-	if(keyUse(KEY_I)) {
+	else if(keyUse(KEY_I)) {
 		s_isAdvancePs = !s_isAdvancePs;
 	}
-	if(keyUse(KEY_O)) {
+	else if(keyUse(KEY_O)) {
 		--s_ps;
 		s_isAdvancePs = 0;
 	}
-	if(keyUse(KEY_P)) {
+	else if(keyUse(KEY_P)) {
 		++s_ps;
 		s_isAdvancePs = 0;
 	}
-	if(keyUse(KEY_V)) {
+	else if(keyUse(KEY_V)) {
 		s_isVectors = !s_isVectors;
 	}
 
@@ -212,10 +199,10 @@ void gsTestTwisterLoop(void) {
 	if(keyUse(KEY_G)) {
 		testGrid(16);
 	}
-	if(keyUse(KEY_H)) {
+	else if(keyUse(KEY_H)) {
 		testGrid(8);
 	}
-	if(keyUse(KEY_J)) {
+	else if(keyUse(KEY_J)) {
 		testGrid(4);
 	}
 

--- a/showcase/src/test/twister.c
+++ b/showcase/src/test/twister.c
@@ -39,7 +39,7 @@ void gsTestTwisterCreate(void) {
 	);
 	s_pBfr = simpleBufferCreate(0,
 		TAG_SIMPLEBUFFER_VPORT, s_pVPort,
-		TAG_SIMPLEBUFFER_BITMAP_FLAGS, BMF_CLEAR,
+		TAG_SIMPLEBUFFER_BITMAP_FLAGS, BMF_CLEAR | BMF_INTERLEAVED,
 		TAG_SIMPLEBUFFER_IS_DBLBUF, 1,
 		TAG_SIMPLEBUFFER_BOUND_WIDTH, SCREEN_PAL_WIDTH + CLIP_MARGIN_X,
 		TAG_SIMPLEBUFFER_BOUND_HEIGHT, SCREEN_PAL_HEIGHT + CLIP_MARGIN_Y,
@@ -169,7 +169,9 @@ void gsTestTwisterLoop(void) {
 
 	viewProcessManagers(s_pView);
 	copProcessBlocks();
+	systemIdleBegin();
 	vPortWaitForEnd(s_pVPort);
+	systemIdleEnd();
 }
 
 void gsTestTwisterDestroy(void) {

--- a/showcase/src/test/twister.c
+++ b/showcase/src/test/twister.c
@@ -14,10 +14,16 @@
 
 #define CLIP_MARGIN_X 32
 #define CLIP_MARGIN_Y 16
-#define TWISTER_CENTER_X 138
-#define TWISTER_CENTER_Y 122
+#define TWISTER_CENTER_X (86+32)
+#define TWISTER_CENTER_Y (128)
 #define TWISTER_CENTER_RADIUS 2
 #define TWISTER_BLOCK_SIZE 32
+#define TWISTER_MIN_BLOCK_X (-(((TWISTER_CENTER_X + TWISTER_BLOCK_SIZE - 1) / TWISTER_BLOCK_SIZE) + 2))
+#define TWISTER_MAX_BLOCK_X (+((((320 - TWISTER_CENTER_X) + TWISTER_BLOCK_SIZE - 1) / TWISTER_BLOCK_SIZE) + 0))
+#define TWISTER_MIN_BLOCK_Y (-(((TWISTER_CENTER_Y + TWISTER_BLOCK_SIZE - 1) / TWISTER_BLOCK_SIZE) + 2))
+#define TWISTER_MAX_BLOCK_Y (+((((256 - TWISTER_CENTER_Y) + TWISTER_BLOCK_SIZE - 1) / TWISTER_BLOCK_SIZE) + 0))
+#define TWISTER_BLOCKS_X (TWISTER_MAX_BLOCK_X - TWISTER_MIN_BLOCK_X)
+#define TWISTER_BLOCKS_Y (TWISTER_MAX_BLOCK_Y - TWISTER_MIN_BLOCK_Y)
 
 static tView *s_pView;
 static tVPort *s_pVPort;
@@ -62,15 +68,13 @@ void gsTestTwisterCreate(void) {
 
 	// Init stuff
 	s_ps = 0;
-	s_isVectors = 1;
-	s_isAdvancePs = 0;
+	s_isVectors = 0;
+	s_isAdvancePs = 1;
 	s_pVPort->pPalette[0] = 0x000;
 	s_pVPort->pPalette[1] = 0x057;
 	s_pVPort->pPalette[2] = 0x49b;
 	s_pVPort->pPalette[3] = 0x8df;
 
-	// testGrid()
-	// cameraSetCoord(s_pBfr->pCamera, 150, 180);
 	randInit(&s_sRand, 1911, 2184);
 
 	// Display view with its viewports
@@ -130,17 +134,15 @@ void gsTestTwisterLoop(void) {
 		uwShift = (uwShift << 1) | ((s_ps >> 4) & 1);
 	// }
 
-	// Original code was using 150,180 as camera coord on 800x600 bitmap.
-	// Following uses same math, but compensates for 0,0 on smaller buffer.
-	for(UBYTE y = 4; y <= 13; ++y) {
-		WORD yy = y * TWISTER_BLOCK_SIZE + uwShift - 180;
-		for(UBYTE x = 3; x <= 14; ++x) {
-			WORD xx = x * TWISTER_BLOCK_SIZE + uwShift - 150;
+	for(BYTE y = TWISTER_MIN_BLOCK_Y; y < TWISTER_MAX_BLOCK_Y; ++y) {
+		WORD yy = TWISTER_CENTER_Y + y * TWISTER_BLOCK_SIZE + uwShift;
+		for(BYTE x = TWISTER_MIN_BLOCK_X; x < TWISTER_MAX_BLOCK_X; ++x) {
+			WORD xx = TWISTER_CENTER_X + x * TWISTER_BLOCK_SIZE + uwShift;
 
-			WORD wSrcX = xx + (16 - y) - x;
-			WORD wSrcY = yy + (16 - y) + x;
+			WORD wSrcX = xx - (y + 1) - (x + 1);
+			WORD wSrcY = yy - (y + 1) + (x + 1);
 			WORD wDstX = xx;
-			WORD wDstY = yy + 16;
+			WORD wDstY = yy;
 			WORD wWidth = TWISTER_BLOCK_SIZE;
 			WORD wHeight = TWISTER_BLOCK_SIZE;
 

--- a/src/ace/managers/blit.c
+++ b/src/ace/managers/blit.c
@@ -155,8 +155,11 @@ UBYTE blitUnsafeCopy(
 		ubShift = uwBlitWidth - (ubDstDelta+wWidth+ubMaskFShift);
 		uwBltCon1 = (ubShift << BSHIFTSHIFT) | BLITREVERSE;
 
-		ulSrcOffs = pSrc->BytesPerRow * (wSrcY + wHeight - 1) + ((wSrcX + wWidth + ubMaskFShift - 1) / 16) * 2;
-		ulDstOffs = pDst->BytesPerRow * (wDstY + wHeight - 1) + ((wDstX + wWidth + ubMaskFShift - 1) / 16) * 2;
+		// Position on the end of last row of the bitmap.
+		// For interleaved, position on the last row of last bitplane.
+		// TODO: fix duplicating bitmapGetByteWidth() check in interleaved branch
+		ulSrcOffs = pSrc->BytesPerRow * (wSrcY + wHeight) - bitmapGetByteWidth(pSrc) + ((wSrcX + wWidth + ubMaskFShift - 1) / 16) * 2;
+		ulDstOffs = pDst->BytesPerRow * (wDstY + wHeight) - bitmapGetByteWidth(pDst) + ((wDstX + wWidth + ubMaskFShift - 1) / 16) * 2;
 	}
 	else {
 		uwBlitWidth = (wWidth+ubDstDelta+15) & 0xFFF0;

--- a/src/ace/managers/blit.c
+++ b/src/ace/managers/blit.c
@@ -131,7 +131,7 @@ UBYTE blitUnsafeCopy(
 	// Helper vars
 	UWORD uwBlitWords, uwBlitWidth;
 	ULONG ulSrcOffs, ulDstOffs;
-	UBYTE ubShift, ubSrcDelta, ubDstDelta, ubWidthDelta, ubMaskFShift, ubMaskLShift, ubPlane;
+	UBYTE ubShift, ubSrcDelta, ubDstDelta, ubWidthDelta, ubMaskFShift, ubMaskLShift;
 	// Blitter register values
 	UWORD uwBltCon0, uwBltCon1, uwFirstMask, uwLastMask;
 	WORD wSrcModulo, wDstModulo;
@@ -148,14 +148,15 @@ UBYTE blitUnsafeCopy(
 		ubMaskLShift = uwBlitWidth - (wWidth+ubMaskFShift);
 		uwFirstMask = 0xFFFF << ubMaskFShift;
 		uwLastMask = 0xFFFF >> ubMaskLShift;
-		if(ubMaskLShift > 16) // Fix for 2-word blits
+		if(ubMaskLShift > 16) { // Fix for 2-word blits
 			uwFirstMask &= 0xFFFF >> (ubMaskLShift-16);
+		}
 
 		ubShift = uwBlitWidth - (ubDstDelta+wWidth+ubMaskFShift);
-		uwBltCon1 = ubShift << BSHIFTSHIFT | BLITREVERSE;
+		uwBltCon1 = (ubShift << BSHIFTSHIFT) | BLITREVERSE;
 
-		ulSrcOffs = pSrc->BytesPerRow * (wSrcY+wHeight-1) + ((wSrcX+wWidth+ubMaskFShift-1)>>3);
-		ulDstOffs = pDst->BytesPerRow * (wDstY+wHeight-1) + ((wDstX+wWidth+ubMaskFShift-1) >> 3);
+		ulSrcOffs = pSrc->BytesPerRow * (wSrcY + wHeight - 1) + ((wSrcX + wWidth + ubMaskFShift - 1) / 16) * 2;
+		ulDstOffs = pDst->BytesPerRow * (wDstY + wHeight - 1) + ((wDstX + wWidth + ubMaskFShift - 1) / 16) * 2;
 	}
 	else {
 		uwBlitWidth = (wWidth+ubDstDelta+15) & 0xFFF0;
@@ -170,33 +171,60 @@ UBYTE blitUnsafeCopy(
 		ubShift = ubDstDelta-ubSrcDelta;
 		uwBltCon1 = ubShift << BSHIFTSHIFT;
 
-		ulSrcOffs = pSrc->BytesPerRow * wSrcY + (wSrcX>>3);
-		ulDstOffs = pDst->BytesPerRow * wDstY + (wDstX>>3);
+		ulSrcOffs = pSrc->BytesPerRow * wSrcY + (wSrcX >> 3);
+		ulDstOffs = pDst->BytesPerRow * wDstY + (wDstX >> 3);
 	}
 
 	uwBltCon0 = (ubShift << ASHIFTSHIFT) | USEB|USEC|USED | ubMinterm;
-	wSrcModulo = pSrc->BytesPerRow - (uwBlitWords<<1);
-	wDstModulo = pDst->BytesPerRow - (uwBlitWords<<1);
 
-	ubPlane = MIN(pSrc->Depth, pDst->Depth);
-	blitWait(); // Don't modify registers when other blit is in progress
-	g_pCustom->bltcon0 = uwBltCon0;
-	g_pCustom->bltcon1 = uwBltCon1;
-	g_pCustom->bltafwm = uwFirstMask;
-	g_pCustom->bltalwm = uwLastMask;
-	g_pCustom->bltbmod = wSrcModulo;
-	g_pCustom->bltcmod = wDstModulo;
-	g_pCustom->bltdmod = wDstModulo;
-	g_pCustom->bltadat = 0xFFFF;
-	while(ubPlane--) {
-		blitWait();
-		// This hell of a casting must stay here or else large offsets get bugged!
-		g_pCustom->bltbpt = pSrc->Planes[ubPlane] + ulSrcOffs;
-		g_pCustom->bltcpt = pDst->Planes[ubPlane] + ulDstOffs;
-		g_pCustom->bltdpt = pDst->Planes[ubPlane] + ulDstOffs;
+	if(
+		bitmapIsInterleaved(pSrc) && bitmapIsInterleaved(pDst) &&
+		pSrc->Depth == pDst->Depth
+	) {
+		wHeight *= pSrc->Depth;
+		wSrcModulo = bitmapGetByteWidth(pSrc) - uwBlitWords * 2;
+		wDstModulo = bitmapGetByteWidth(pDst) - uwBlitWords * 2;
+
+		blitWait(); // Don't modify registers when other blit is in progress
+		g_pCustom->bltcon0 = uwBltCon0;
+		g_pCustom->bltcon1 = uwBltCon1;
+		g_pCustom->bltafwm = uwFirstMask;
+		g_pCustom->bltalwm = uwLastMask;
+		g_pCustom->bltbmod = wSrcModulo;
+		g_pCustom->bltcmod = wDstModulo;
+		g_pCustom->bltdmod = wDstModulo;
+		g_pCustom->bltadat = 0xFFFF;
+		g_pCustom->bltbpt = &pSrc->Planes[0][ulSrcOffs];
+		g_pCustom->bltcpt = &pDst->Planes[0][ulDstOffs];
+		g_pCustom->bltdpt = &pDst->Planes[0][ulDstOffs];
 
 		g_pCustom->bltsize = (wHeight << HSIZEBITS) | uwBlitWords;
 	}
+	else {
+		wSrcModulo = pSrc->BytesPerRow - uwBlitWords * 2;
+		wDstModulo = pDst->BytesPerRow - uwBlitWords * 2;
+		UBYTE ubPlane = MIN(pSrc->Depth, pDst->Depth);
+
+		blitWait(); // Don't modify registers when other blit is in progress
+		g_pCustom->bltcon0 = uwBltCon0;
+		g_pCustom->bltcon1 = uwBltCon1;
+		g_pCustom->bltafwm = uwFirstMask;
+		g_pCustom->bltalwm = uwLastMask;
+		g_pCustom->bltbmod = wSrcModulo;
+		g_pCustom->bltcmod = wDstModulo;
+		g_pCustom->bltdmod = wDstModulo;
+		g_pCustom->bltadat = 0xFFFF;
+		while(ubPlane--) {
+			blitWait();
+			// This hell of a casting must stay here or else large offsets get bugged!
+			g_pCustom->bltbpt = &pSrc->Planes[ubPlane][ulSrcOffs];
+			g_pCustom->bltcpt = &pDst->Planes[ubPlane][ulDstOffs];
+			g_pCustom->bltdpt = &pDst->Planes[ubPlane][ulDstOffs];
+
+			g_pCustom->bltsize = (wHeight << HSIZEBITS) | uwBlitWords;
+		}
+	}
+
 #endif // AMIGA
 	return 1;
 }

--- a/src/ace/utils/bitmap.c
+++ b/src/ace/utils/bitmap.c
@@ -399,6 +399,8 @@ void bitmapDestroy(tBitMap *pBitMap) {
 }
 
 UBYTE bitmapIsInterleaved(const tBitMap *pBitMap) {
+	// The check for depth is because of how bitmapGetByteWidth() works
+	// if byte width were to be stored in bitmap struct, the depth check can be skipped.
 	return (pBitMap->Depth > 1) && (pBitMap->Flags & BMF_INTERLEAVED);
 }
 


### PR DESCRIPTION
<!--- Use this only if you've made non-breaking improvements or bugfixes -->

## Description
Makes the blitCopy() significantly faster when using on interleaved bitmaps.
The showcase twister is faster now.

Also fixes modulo calculations for blitCopyAligned() when using mixed interleaved/non-interleaved bitmaps.

## Checklist
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
