### PR TITLE
add assume.c/.h, convert assert-like error checks into assume statements

### DIFF
--- a/include/ace/utils/assume.h
+++ b/include/ace/utils/assume.h
@@ -1,0 +1,43 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+#ifndef _ACE_UTILS_ASSUME_H_
+#define _ACE_UTILS_ASSUME_H_
+
+#include <ace/types.h>
+#include <ace/managers/system.h>
+#include <ace/managers/log.h>
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+#if defined(ACE_DEBUG)
+
+#define assume(cond) _assume(cond, 0, __FILE__, __LINE__)
+#define assumeMsg(cond, szErrorMsg) _assume(cond, szErrorMsg, __FILE__, __LINE__)
+#define assumeNotNull(ptr) assumeMsg(ptr != 0, "Null pointer: " #ptr);
+
+void _assume(ULONG ulExprValue, const char *szErrorMsg, const char *szFile, ULONG ulLine);
+
+#else
+
+#if __GNUC__ >= 13
+#define assume(cond) __attribute__((__assume__(cond)))
+#else
+// https://stackoverflow.com/questions/25667901/ - this isn't optimized away!
+// #define assume(cond) do { if (!(cond)) __builtin_unreachable(); } while (0)
+// https://stackoverflow.com/questions/30919802/ - no footprint on code
+#define assume(cond) ((void) sizeof(cond))
+#endif
+#define assumeMsg(cond, szErrorMsg) assume(cond)
+#define assumeNotNull(ptr) assume(ptr != 0)
+
+#endif
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif // _ACE_UTILS_ASSUME_H_

--- a/src/ace/managers/blit.c
+++ b/src/ace/managers/blit.c
@@ -4,6 +4,7 @@
 
 #include <ace/managers/blit.h>
 #include <ace/managers/system.h>
+#include <ace/utils/assume.h>
 
 #define BLIT_LINE_OR ((ABC | ABNC | NABC | NANBC) | (SRCA | SRCC | DEST))
 #define BLIT_LINE_XOR ((ABNC | NABC | NANBC) | (SRCA | SRCC | DEST))
@@ -313,10 +314,10 @@ UBYTE blitSafeCopyAligned(
 	tBitMap *pDst, WORD wDstX, WORD wDstY, WORD wWidth, WORD wHeight,
 	UWORD uwLine, const char *szFile
 ) {
-	if((wSrcX | wDstX | wWidth) & 0x000F) {
-		logWrite("ERR: Dimensions are not divisible by 16\n");
-		return 0;
-	}
+	assumeMsg((wSrcX & 0xF) == 0, "wSrcX isn't divisible by 16");
+	assumeMsg((wDstX & 0xF) == 0, "wDstX isn't divisible by 16");
+	assumeMsg((wWidth & 0xF) == 0, "wWidth isn't divisible by 16");
+
 	if(!blitCheck(
 		pSrc, wSrcX, wSrcY, pDst, wDstX, wDstY, wWidth, wHeight, uwLine, szFile
 	)) {

--- a/src/ace/managers/bob.c
+++ b/src/ace/managers/bob.c
@@ -7,6 +7,7 @@
 #include <ace/managers/system.h>
 #include <ace/managers/blit.h>
 #include <ace/utils/custom.h>
+#include <ace/utils/assume.h>
 
 #if !defined(ACE_NO_BOB_WRAP_Y)
 // Enables support for Y-wrapping of bobs. Required for scroll- and tileBuffer.
@@ -90,13 +91,8 @@ void bobManagerCreate(
 		pFront, pBack, uwAvailHeight
 	);
 
-	if(!bitmapIsInterleaved(pFront)) {
-		logWrite("ERR: front buffer bitmap %p isn't interleaved\n", pFront);
-	}
-
-	if(!bitmapIsInterleaved(pBack)) {
-		logWrite("ERR: back buffer bitmap %p isn't interleaved\n", pBack);
-	}
+	assumeMsg(bitmapIsInterleaved(pFront), "Front buffer bitmap isn't interleaved");
+	assumeMsg(bitmapIsInterleaved(pBack), "Back buffer bitmap isn't interleaved");
 
 	s_ubBpp = pFront->Depth;
 	s_pQueues[0].pDst = pBack;
@@ -427,12 +423,7 @@ void bobBegin(tBitMap *pBuffer) {
 	}
 #ifdef GAME_DEBUG
 	UWORD uwDrawLimit = s_pQueues[0].pBg->Rows * s_pQueues[0].pBg->Depth;
-	if(uwDrawnHeight > uwDrawLimit) {
-		logWrite(
-			"ERR: BG restore out of bounds: used %hu, limit: %hu",
-			uwDrawnHeight, uwDrawLimit
-		);
-	}
+	assumeMsg(uwDrawnHeight <= uwDrawLimit, "BG restore out of bounds");
 #endif
 	s_ubBobsSaved = 0;
 	s_ubBobsDrawn = 0;

--- a/src/ace/managers/copper.c
+++ b/src/ace/managers/copper.c
@@ -5,8 +5,9 @@
 #include <ace/managers/copper.h>
 #ifdef AMIGA
 #include <stdarg.h>
-#include <ace/managers/system.h>
 #include <limits.h>
+#include <ace/managers/system.h>
+#include <ace/utils/assume.h>
 #include <proto/exec.h>
 
 tCopManager g_sCopManager;
@@ -203,17 +204,9 @@ tCopList *copListCreate(void *pTagList, ...) {
 		ULONG ulListSize = tagGet(
 			pTagList, vaTags, TAG_COPPER_RAW_COUNT, ulInvalidSize
 		);
-		if(ulListSize == ulInvalidSize) {
-			logWrite("ERR: no size specified for raw list\n");
-			goto fail;
-		}
-		if(ulListSize > USHRT_MAX) {
-			logWrite(
-				"ERR: raw copperlist size too big: %lu, max is %u\n",
-				ulListSize, USHRT_MAX
-			);
-			goto fail;
-		}
+		assumeMsg(ulListSize != ulInvalidSize, "No size specified for raw list");
+		assumeMsg(ulListSize <= USHRT_MAX, "Raw copperlist size is too big");
+
 		logWrite("RAW mode, size: %lu + WAIT(0xFFFF)\n", ulListSize);
 		// Front bfr
 		pCopList->pFrontBfr->uwCmdCount = ulListSize+1;
@@ -233,12 +226,6 @@ tCopList *copListCreate(void *pTagList, ...) {
 	logBlockEnd("copListCreate()");
 	va_end(vaTags);
 	return pCopList;
-
-fail:
-	va_end(vaTags);
-	copListDestroy(pCopList);
-	logBlockEnd("copListCreate()");
-	return 0;
 }
 
 void copListDestroy(tCopList *pCopList) {

--- a/src/ace/managers/joy.c
+++ b/src/ace/managers/joy.c
@@ -10,6 +10,7 @@
 #include <ace/managers/log.h>
 #include <ace/managers/system.h>
 #include <ace/utils/custom.h>
+#include <ace/utils/assume.h>
 
 #if defined ACE_DEBUG
 static UBYTE s_bInitCount = 0;
@@ -34,19 +35,15 @@ static inline const char *myAllocMiscResource(
 
 void joyOpen(void) {
 #if defined(ACE_DEBUG)
-	if(s_bInitCount++ != 0) {
-		// You should call keyCreate() only once
-		logWrite("ERR: Joy already initialized!\n");
-	}
+	assumeMsg(s_bInitCount == 0, "Joy already initialized");
+	++s_bInitCount;
 #endif
 }
 
 void joyClose(void) {
 #if defined(ACE_DEBUG)
-	if(s_bInitCount-- != 1) {
-		// You should call joyClose() only once for each joyCreate()
-		logWrite("ERR: Joy was initialized multiple times!\n");
-	}
+	--s_bInitCount;
+	assumeMsg(s_bInitCount == 0, "Joy was initialized multiple times");
 #endif
 	joyDisableParallel();
 }

--- a/src/ace/managers/key.c
+++ b/src/ace/managers/key.c
@@ -7,6 +7,7 @@
 #include <ace/managers/memory.h>
 #include <ace/managers/system.h>
 #include <ace/utils/custom.h>
+#include <ace/utils/assume.h>
 #include <hardware/intbits.h> // INTB_PORTS
 #define KEY_RELEASED_BIT 1
 
@@ -94,10 +95,8 @@ const UBYTE g_pToAscii[] = {
 void keyCreate(void) {
 	logBlockBegin("keyCreate()");
 #if defined(ACE_DEBUG)
-	if(s_bInitCount++ != 0) {
-		// You should call keyCreate() only once
-		logWrite("ERR: Keyboard already initialized!\n");
-	}
+	assumeMsg(s_bInitCount == 0, "Keyboard already initialized");
+	++s_bInitCount;
 #endif
 	systemSetCiaInt(CIA_A, CIAICRB_SERIAL, keyIntServer, &g_sKeyManager);
 	logBlockEnd("keyCreate()");
@@ -106,10 +105,8 @@ void keyCreate(void) {
 void keyDestroy(void) {
 	logBlockBegin("keyDestroy()");
 #if defined(ACE_DEBUG)
-	if(s_bInitCount-- != 1) {
-		// You should call keyDestroy() only once for each keyCreate()
-		logWrite("ERR: Keyboard was initialized multiple times!\n");
-	}
+	--s_bInitCount;
+	assumeMsg(s_bInitCount == 0, "Keyboard was initialized multiple times");
 #endif
 	systemSetCiaInt(CIA_A, CIAICRB_SERIAL, 0, 0);
 	logBlockEnd("keyDestroy()");

--- a/src/ace/managers/log.c
+++ b/src/ace/managers/log.c
@@ -6,6 +6,7 @@
 #include <string.h>
 #include <ace/macros.h>
 #include <ace/managers/system.h>
+#include <ace/utils/assume.h>
 #ifdef ACE_DEBUG
 
 // Globals
@@ -243,9 +244,8 @@ void _logPushInt(void) {
 }
 
 void _logPopInt(void) {
-	if(--g_sLogManager.wInterruptDepth < 0) {
-		logWrite("ERR: INT DEPTH NEGATIVE!\n");
-	}
+	--g_sLogManager.wInterruptDepth;
+	assumeMsg(g_sLogManager.wInterruptDepth >= 0, "INT DEPTH NEGATIVE");
 }
 
 #endif // ACE_DEBUG

--- a/src/ace/managers/rand.c
+++ b/src/ace/managers/rand.c
@@ -9,6 +9,7 @@
 #include <ace/managers/rand.h>
 #include <ace/managers/memory.h>
 #include <ace/managers/log.h>
+#include <ace/utils/assume.h>
 
 // Coefficients are chosen from the table of original post, with restriction
 // to use shifts lesser than 8 in order to let compiler use "shift immediate"
@@ -28,6 +29,7 @@ tRandManager *randCreate(UWORD uwSeed1, UWORD uwSeed2) {
 }
 
 void randDestroy(tRandManager *pRand) {
+	assumeNotNull(pRand);
 	memFree(pRand, sizeof(*pRand));
 }
 
@@ -35,11 +37,9 @@ void randInit(tRandManager *pRand, UWORD uwSeed1, UWORD uwSeed2) {
 	logBlockBegin(
 		"randInit(pRand: %p, uwSeed1: %hu, uwSeed2: %hu)", pRand, uwSeed1, uwSeed2
 	);
-	if(uwSeed1 == 0 || uwSeed2 == 0) {
-		logWrite("ERR: Seeds can't be zero!\n");
-		logBlockEnd("randInit()");
-		return;
-	}
+	assumeNotNull(pRand);
+	assumeMsg(uwSeed1 != 0, "Seeds can't be zero");
+	assumeMsg(uwSeed2 != 0, "Seeds can't be zero");
 
 	pRand->uwState1 = uwSeed1;
 	pRand->uwState2 = uwSeed2;
@@ -47,6 +47,8 @@ void randInit(tRandManager *pRand, UWORD uwSeed1, UWORD uwSeed2) {
 }
 
 UWORD randUw(tRandManager *pRand) {
+	assumeNotNull(pRand);
+
   UWORD t = (pRand->uwState1 ^ (pRand->uwState1 << RAND_COEFF_A));
   pRand->uwState1 = pRand->uwState2;
 	pRand->uwState2 = (pRand->uwState2 ^ (pRand->uwState2 >> RAND_COEFF_C)) ^ (t ^ (t >> RAND_COEFF_B));
@@ -54,24 +56,34 @@ UWORD randUw(tRandManager *pRand) {
 }
 
 UWORD randUwMax(tRandManager *pRand, UWORD uwMax) {
+	assumeNotNull(pRand);
+
 	return randUw(pRand) % (uwMax + 1);
 }
 
 UWORD randUwMinMax(tRandManager *pRand, UWORD uwMin, UWORD uwMax) {
+	assumeNotNull(pRand);
+
 	return uwMin + randUwMax(pRand, uwMax - uwMin);
 }
 
 ULONG randUl(tRandManager *pRand) {
+	assumeNotNull(pRand);
+
 	UWORD uwUpper = randUw(pRand);
 	UWORD uwLower = randUw(pRand);
 	return (uwUpper << 16) | (uwLower);
 }
 
 ULONG randUlMax(tRandManager *pRand, ULONG ulMax) {
+	assumeNotNull(pRand);
+
 	return randUl(pRand) % (ulMax + 1);
 }
 
 ULONG randUlMinMax(tRandManager *pRand, ULONG ulMin, ULONG ulMax) {
+	assumeNotNull(pRand);
+
 	return ulMin + randUlMax(pRand, ulMax - ulMin);
 }
 

--- a/src/ace/managers/state.c
+++ b/src/ace/managers/state.c
@@ -4,26 +4,9 @@
 
 #include <ace/managers/state.h>
 #include <ace/managers/log.h>
+#include <ace/utils/assume.h>
 
 /* Functions */
-
-#ifdef ACE_DEBUG
-
-#define checkNull(pPointer) _checkNull(pPointer, "##pPointer", __FILE__, __LINE__)
-static void _checkNull(
-	void *pPointer, const char *szPointerName, const char *szFile, UWORD uwLine
-) {
-	if (!pPointer) {
-		logWrite(
-			"ERR: Pointer %s is zero at %s:%u! Crash imminent!\n",
-			szPointerName, szFile, uwLine
-		);
-	}
-}
-
-#else
-#define checkNull(pPointer) do {} while(0)
-#endif
 
 tStateManager *stateManagerCreate(void) {
 	logBlockBegin("stateManagerCreate()");
@@ -37,11 +20,9 @@ tStateManager *stateManagerCreate(void) {
 
 void stateManagerDestroy(tStateManager *pStateManager) {
 	logBlockBegin("stateManagerDestroy(pStateManager: %p)", pStateManager);
-
-	checkNull(pStateManager);
+	assumeNotNull(pStateManager);
 
 	statePopAll(pStateManager);
-
 	memFree(pStateManager, sizeof(tStateManager));
 
 	logBlockEnd("stateManagerDestroy()");
@@ -57,6 +38,7 @@ tState *stateCreate(
 	);
 
 	tState *pState = memAllocFast(sizeof(tState));
+	assumeNotNull(pState); // TODO: gracefully fail?
 
 	pState->cbCreate = cbCreate;
 	pState->cbLoop = cbLoop;
@@ -72,8 +54,7 @@ tState *stateCreate(
 
 void stateDestroy(tState *pState) {
 	logBlockBegin("stateDestroy(pState: %p)", pState);
-
-	checkNull(pState);
+	assumeNotNull(pState);
 
 	memFree(pState, sizeof(tState));
 
@@ -85,9 +66,8 @@ void statePush(tStateManager *pStateManager, tState *pState) {
 		"statePush(pStateManager: %p, pState: %p)",
 		pStateManager, pState
 	);
-
-	checkNull(pStateManager);
-	checkNull(pState);
+	assumeNotNull(pStateManager);
+	assumeNotNull(pState);
 
 	if (pStateManager->pCurrent && pStateManager->pCurrent->cbSuspend) {
 		pStateManager->pCurrent->cbSuspend();
@@ -105,8 +85,7 @@ void statePush(tStateManager *pStateManager, tState *pState) {
 
 void statePop(tStateManager *pStateManager) {
 	logBlockBegin("statePop(pStateManager: %p)", pStateManager);
-
-	checkNull(pStateManager);
+	assumeNotNull(pStateManager);
 
 	if (pStateManager->pCurrent && pStateManager->pCurrent->cbDestroy) {
 		pStateManager->pCurrent->cbDestroy();
@@ -124,8 +103,7 @@ void statePop(tStateManager *pStateManager) {
 
 void statePopAll(tStateManager *pStateManager) {
 	logBlockBegin("statePopAll(pStateManager: %p)", pStateManager);
-
-	checkNull(pStateManager);
+	assumeNotNull(pStateManager);
 
 	while (pStateManager->pCurrent) {
 		if (pStateManager->pCurrent->cbDestroy) {
@@ -143,9 +121,8 @@ void stateChange(tStateManager *pStateManager, tState *pState) {
 		"stateChange(pStateManager: %p, pState: %p)",
 		pStateManager, pState
 	);
-
-	checkNull(pStateManager);
-	checkNull(pState);
+	assumeNotNull(pStateManager);
+	assumeNotNull(pState);
 
 	if (pStateManager->pCurrent && pStateManager->pCurrent->cbDestroy) {
 		pStateManager->pCurrent->cbDestroy();
@@ -168,7 +145,7 @@ void stateChange(tStateManager *pStateManager, tState *pState) {
 }
 
 void stateProcess(tStateManager *pStateManager) {
-	checkNull(pStateManager);
+	assumeNotNull(pStateManager);
 
 	if (pStateManager->pCurrent && pStateManager->pCurrent->cbLoop) {
 		pStateManager->pCurrent->cbLoop();

--- a/src/ace/utils/assume.c
+++ b/src/ace/utils/assume.c
@@ -1,0 +1,25 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+#include <ace/utils/assume.h>
+
+#if defined(ACE_DEBUG)
+
+void _assume(ULONG ulExprValue, const char *szErrorMsg, const char *szFile, ULONG ulLine) {
+	if(!ulExprValue) {
+		if(szErrorMsg) {
+			logWrite("ERR: Assumption failed at %s:%lu - %s\n", szFile, ulLine, szErrorMsg);
+		}
+		else {
+			logWrite("ERR: Assumption failed at %s:%lu\n", szFile, ulLine);
+		}
+#if defined(BARTMAN_GCC)
+		__builtin_trap();
+#else
+		systemKill("Assumption failed - see logs for details");
+#endif
+	}
+}
+
+#endif

--- a/src/ace/utils/palette.c
+++ b/src/ace/utils/palette.c
@@ -18,7 +18,6 @@ void paletteLoad(const char *szFileName, UWORD *pPalette, UBYTE ubMaxLength) {
 
 	pFile = fileOpen(szFileName, "r");
 	if(!pFile) {
-		logWrite("ERR: File doesn't exist!\n");
 		logBlockEnd("paletteLoad()");
 		return;
 	}

--- a/src/ace/utils/string.c
+++ b/src/ace/utils/string.c
@@ -4,13 +4,13 @@
 
 #include <ace/utils/string.h>
 #include <ace/managers/log.h>
+#include <ace/utils/assume.h>
 
-char *stringDecimalFromULong(ULONG ulVal, char *pDst) {
+char *stringDecimalFromULong(ULONG ulVal, char *szDest) {
 	// Modified from https://github.com/german-one/itostr/blob/master/itostr.c
-	// Relies on prior verification that buffer != NULL and bufsize != 0
-	// TODO: add ACE checks for that
+	assumeNotNull(szDest);
 
-	char* pEnd = pDst; // Pointer to the position to write
+	char* pEnd = szDest; // Pointer to the position to write
 	do {
 		// Get the value of the rightmost digit
 		// (avoid modulo, it would perform another slow division)
@@ -24,12 +24,12 @@ char *stringDecimalFromULong(ULONG ulVal, char *pDst) {
 	// Assign the terminating null and decrease the pointer in order to point
 	// To the last digit written
 	*pEnd-- = '\0';
-	while (pDst < pEnd) {
+	while (szDest < pEnd) {
 		// Reverse the digits (only the digits) in the array because they are
 		// LTR written but we need them in RTL order
 		char transfer = *pEnd;
-		*pEnd-- = *pDst;
-		*pDst++ = transfer;
+		*pEnd-- = *szDest;
+		*szDest++ = transfer;
 	}
 	return pWriteEnd;
 }
@@ -41,21 +41,29 @@ char charToUpper(char c) {
 	return c;
 }
 
-void strToUpper(const char *szSrc, char *szDst) {
+void strToUpper(const char *szSrc, char *szDest) {
+	assumeNotNull(szSrc);
+	assumeNotNull(szDest);
+
 	while(*szSrc) {
 		char c = *(szSrc++);
 		c = charToUpper(c);
-		*(szDst++) = c;
+		*(szDest++) = c;
 	}
-	*szDst = '\0';
+	*szDest = '\0';
 }
 
 UBYTE stringIsEmpty(const char *szStr) {
+	assumeNotNull(szStr);
+
 	UBYTE isEmpty = (szStr[0] == '\0');
 	return isEmpty;
 }
 
 char *stringCopy(const char *szSrc, char *szDest) {
+	assumeNotNull(szSrc);
+	assumeNotNull(szDest);
+
 	while(*szSrc != '\0') {
 		*(szDest++) = *(szSrc++);
 	};
@@ -64,9 +72,9 @@ char *stringCopy(const char *szSrc, char *szDest) {
 }
 
 char *stringCopyLimited(const char *szSrc, char *szDest, UWORD uwMaxLength) {
-	if(uwMaxLength == 0) {
-		logWrite("ERR: stringCopyLimited(szSrc: '%s') uwMaxLength is zero!\n", szSrc);
-	}
+	assumeNotNull(szSrc);
+	assumeNotNull(szDest);
+	assumeMsg(uwMaxLength != 0, "uwMaxLength is zero");
 
 	while(*szSrc != '\0' && --uwMaxLength > 0) {
 		*(szDest++) = *(szSrc++);

--- a/src/ace/utils/tag.c
+++ b/src/ace/utils/tag.c
@@ -4,13 +4,10 @@
 
 #include <ace/utils/tag.h>
 #include <ace/managers/log.h>
+#include <ace/utils/assume.h>
 
 ULONG tagGet(void *pTagListPtr, va_list vaSrcList, tTag ulTagToFind, ULONG ulOnNotFound) {
-	if(pTagListPtr) {
-		// TODO
-		logWrite("ERR: Unimplemented in tagFindString()");
-		return ulOnNotFound;
-	}
+	assumeMsg(pTagListPtr == 0, "Unimplemented parsing pTagListPtr");
 
 	va_list vaWorkList;
 	va_copy(vaWorkList, vaSrcList);


### PR DESCRIPTION
## Description

Adds assertion-like mechanism, which falls back to GCC13's assume attribute. Closes #204. On Bartman suite, this results with a breakpoint on where the failed error check took place.

## Motivation and Context

Getting used to errors or not finding them among logs is quite common. Proposed feature makes them more apparent and also unifies the behavior on failed, often critical, error checks.

It also takes the burden off of failing gracefully of some parts, especially those, which shouldn't ever fail if user code is well formed.

Also generalizes `checkNull()` approach introduced by @approxit in state manager, adding it to remaining part of codebase.

## How Has This Been Tested?

Built Aminer with it, ran the game for a while, so apparently there are no regressions. Did some dummy checks to see if breakpoints on failed assumptions trigger properly.

## Types of changes

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist

- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
