### PR TITLE
generic main: add ability to disable timer manager

### DIFF
--- a/include/ace/generic/main.h
+++ b/include/ace/generic/main.h
@@ -107,7 +107,9 @@ int main(void) {
 	systemCreate();
 	logOpen(GENERIC_MAIN_LOG_PATH);
 	memCreate();
+#if !defined(GENERIC_MAIN_NO_TIMER)
 	timerCreate();
+#endif
 
 	blitManagerCreate();
 	copCreate();
@@ -115,7 +117,9 @@ int main(void) {
 	// Call user callbacks:
 	genericCreate();
 	while (GENERIC_MAIN_LOOP_CONDITION) {
+#if !defined(GENERIC_MAIN_NO_TIMER)
 		timerProcess();
+#endif
 		genericProcess();
 	}
 	genericDestroy();
@@ -123,7 +127,9 @@ int main(void) {
 	copDestroy();
 	blitManagerDestroy();
 
+#if !defined(GENERIC_MAIN_NO_TIMER)
 	timerDestroy();
+#endif
 	memDestroy();
 	logClose();
 	systemDestroy();


### PR DESCRIPTION
<!--- Use this only if you've made non-breaking improvements or bugfixes -->

## Description

Adds ability to disable timer manager in generic main code.

I've left it on by default, because currently log blocks depend on it to display time measurements (like they were correct anyway lol). Also, this approach won't break already made games.

## Checklist
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
