### PR TITLE
bitmap_conv: add support for EHB palettes

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -161,15 +161,19 @@ endfunction()
 
 function(convertBitmaps)
 	getToolPath(bitmap_conv TOOL_BITMAP_CONV)
-	set(options INTERLEAVED)
+	set(options INTERLEAVED EHB)
 	set(oneValArgs TARGET PALETTE MASK_COLOR)
 	set(multiValArgs SOURCES DESTINATIONS MASKS)
 	cmake_parse_arguments(
 		convertBitmaps "${options}" "${oneValArgs}" "${multiValArgs}" ${ARGN}
 	)
 
+	if(${convertBitmaps_EHB})
+		list(APPEND extraFlags "-ehb")
+	endif()
+
 	if(${convertBitmaps_INTERLEAVED})
-		set(extraFlags -i)
+		list(APPEND extraFlags "-i")
 	endif()
 
 	list(LENGTH convertBitmaps_SOURCES srcCount)

--- a/tools/src/bitmap_conv.cpp
+++ b/tools/src/bitmap_conv.cpp
@@ -16,6 +16,7 @@ void printUsage(const std::string &szAppName)
 	print("extraOpts:\n");
 	print("\t-o outPath\tSpecify output file path. If ommited, it will perform default conversion\n");
 	print("\t-i\t\tEnable interleaved mode\n");
+	print("\t-ehb\t\tExtend palette with EHB colors\n");
 	print("\t-mc #RRGGBB\tTreat color #RRGGBB as mask\n");
 	print("\t-mf outMaskPath\tSpecify path for mask.bm file. If omitted, it will try\n");
 	print("\t\t\tto use same path as .bm with \"_mask.bm\" suffix\n");
@@ -38,6 +39,7 @@ int main(int lArgCount, const char *pArgs[])
 	std::string szPalette = pArgs[1], szInput = pArgs[2];
 	std::string szOutput = "", szMask = "";
 	bool isWriteInterleaved = false;
+	bool isEhb = false;
 	bool isEnabledOutputMask = true;
 	bool isEnabledOutput = true;
 	bool isMaskColor = false;
@@ -50,6 +52,9 @@ int main(int lArgCount, const char *pArgs[])
 		}
 		else if(pArgs[ArgIndex] == std::string("-i")) {
 			isWriteInterleaved = true;
+		}
+		else if(pArgs[ArgIndex] == std::string("-ehb")) {
+			isEhb = true;
 		}
 		else if(pArgs[ArgIndex] == std::string("-mc") && ArgIndex < lArgCount - 1) {
 			isMaskColor = true;
@@ -105,6 +110,11 @@ int main(int lArgCount, const char *pArgs[])
 		nLog::error("Couldn't read palette '{}'", szPalette);
 		return EXIT_FAILURE;
 	}
+	if(isEhb) {
+		if(!Palette.convertToEhb()) {
+			nLog::error("Couldn't convert palette to EHB! Does it have at most 32 colors?");
+		}
+	}
 
 
 	// Load input
@@ -144,7 +154,8 @@ int main(int lArgCount, const char *pArgs[])
 			tRgb MaskAntiColor(~MaskColor.ubR, ~MaskColor.ubG, ~MaskColor.ubB);
 			// Generate mask palette - 0 is transparent, everything else is not
 			if(isWriteInterleaved) {
-				PaletteMask.m_vColors.resize(1 << Palette.getBpp(), tRgb(1, 1, 1));
+				auto PaletteSize = 1u << Palette.getBpp();
+				PaletteMask.m_vColors.resize(PaletteSize, tRgb(1, 1, 1));
 				PaletteMask.m_vColors.front() = MaskColor;
 				PaletteMask.m_vColors.back() = MaskAntiColor;
 			}

--- a/tools/src/common/palette.cpp
+++ b/tools/src/common/palette.cpp
@@ -285,3 +285,16 @@ std::uint8_t tPalette::getBpp(void) const {
 	}
 	return ubBpp;
 }
+
+bool tPalette::convertToEhb(void)
+{
+	if(m_vColors.size() > 32) {
+		return false;
+	}
+
+	m_vColors.resize(64);
+	for(std::size_t i = 0; i < 32; ++i) {
+		m_vColors[i + 32] = m_vColors[i].toEhb();
+	}
+	return true;
+}

--- a/tools/src/common/palette.h
+++ b/tools/src/common/palette.h
@@ -34,6 +34,8 @@ public:
 
 	std::uint8_t getBpp(void) const;
 
+	bool convertToEhb(void);
+
 	std::vector<tRgb> m_vColors;
 
 	tPalette(void) {}

--- a/tools/src/common/parse.h
+++ b/tools/src/common/parse.h
@@ -24,6 +24,17 @@ static inline bool toInt32(
 	return true;
 }
 
+template<typename t_tValue>
+static bool hexToRange(const std::string &szVal, t_tValue Min, t_tValue Max, t_tValue &Out) {
+	auto Value = std::stoll(szVal, nullptr, 16);
+	if(Value < Min || Max < Value) {
+		return false;
+	}
+
+	Out = static_cast<t_tValue>(Value);
+	return true;
+}
+
 } // namespace nParse
 
 

--- a/tools/src/common/rgb.cpp
+++ b/tools/src/common/rgb.cpp
@@ -5,19 +5,20 @@
 #include "rgb.h"
 #include <fmt/format.h>
 #include <stdexcept>
+#include "parse.h"
 
 tRgb::tRgb(const std::string &szCode)
 {
 	if(szCode[0] == '#') {
 		if(szCode.length() == 3 + 1) {
-			this->ubR = std::stoul(szCode.substr(1, 1), nullptr, 16);
-			this->ubG = std::stoul(szCode.substr(2, 1), nullptr, 16);
-			this->ubB = std::stoul(szCode.substr(3, 1), nullptr, 16);
+			nParse::hexToRange<std::uint8_t>(szCode.substr(1, 1), 0, 15, this->ubR);
+			nParse::hexToRange<std::uint8_t>(szCode.substr(2, 1), 0, 15, this->ubG);
+			nParse::hexToRange<std::uint8_t>(szCode.substr(3, 1), 0, 15, this->ubB);
 		}
 		else if(szCode.length() == 6 + 1) {
-			this->ubR = std::stoul(szCode.substr(1, 2), nullptr, 16);
-			this->ubG = std::stoul(szCode.substr(3, 2), nullptr, 16);
-			this->ubB = std::stoul(szCode.substr(5, 2), nullptr, 16);
+			nParse::hexToRange<std::uint8_t>(szCode.substr(1, 2), 0, 15, this->ubR);
+			nParse::hexToRange<std::uint8_t>(szCode.substr(3,2), 0, 15, this->ubG);
+			nParse::hexToRange<std::uint8_t>(szCode.substr(5, 2), 0, 15, this->ubB);
 		}
 		else {
 			throw std::runtime_error(fmt::format("Unknown RGB hex format: {}", szCode));
@@ -33,6 +34,15 @@ tRgb tRgb::to12Bit(void) const
 	auto R4 = ((this->ubR + 16) / 17);
 	auto G4 = ((this->ubG + 16) / 17);
 	auto B4 = ((this->ubB + 16) / 17);
+	auto Out = tRgb((R4 << 4) | R4, (G4 << 4) | G4, (B4 << 4) | B4);
+	return Out;
+}
+
+tRgb tRgb::toEhb(void) const
+{
+	auto R4 = ((this->ubR + 16) / 17) >> 1;
+	auto G4 = ((this->ubG + 16) / 17) >> 1;
+	auto B4 = ((this->ubB + 16) / 17) >> 1;
 	auto Out = tRgb((R4 << 4) | R4, (G4 << 4) | G4, (B4 << 4) | B4);
 	return Out;
 }

--- a/tools/src/common/rgb.h
+++ b/tools/src/common/rgb.h
@@ -26,6 +26,8 @@ struct tRgb {
 
 	tRgb to12Bit(void) const;
 
+	tRgb toEhb(void) const;
+
 	bool operator == (const tRgb &Rhs) const {
 		return ubB == Rhs.ubB && ubG == Rhs.ubG && ubR == Rhs.ubR;
 	}


### PR DESCRIPTION
## Description
Adds support for EHB-enabled image conversion.
The new switch simply expands loaded palette with EHB color counterparts so that user doesn't have to pass in 64-color palette created only for purpose of bitmap conversion.

Also, minor cleanup in tool's code reduces amount of warnings under MSVC.

## Checklist
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
