### PR TITLE
Add global hires support

### DIFF
--- a/docs/programming/blit.md
+++ b/docs/programming/blit.md
@@ -102,9 +102,7 @@ static tVPort *s_pVpMain; // Viewport for playfield
 static tSimpleBufferManager *s_pMainBuffer;
 
 void gameGsCreate(void) {
-  s_pView = viewCreate(0,
-    TAG_VIEW_GLOBAL_PALETTE, 1,
-  TAG_END);
+  s_pView = viewCreate(0, TAG_END);
 
   // Viewport for score bar - on top of screen
   s_pVpScore = vPortCreate(0,

--- a/docs/programming/loading_images.md
+++ b/docs/programming/loading_images.md
@@ -59,8 +59,8 @@ void gameGsCreate(void) {
 
 //-------------------------------------------------------------- NEW STUFF START
   // Load palette from file to first viewport - second one will use the same
-  // due to TAG_VIEW_GLOBAL_PALETTE being set to 1. We're using 4BPP display,
-  // which means max 16 colors.
+  // due to TAG_VIEW_GLOBAL_PALETTE being by default set to 1. We're using
+  // 4BPP display, which means max 16 colors.
   paletteLoad("data/pong.plt", s_pVpScore->pPalette, 16);
 
   // Load background graphics and draw them immediately

--- a/docs/programming/moving_blits.md
+++ b/docs/programming/moving_blits.md
@@ -139,9 +139,7 @@ static UWORD uwPaddleRightPosY = 0;
 //---------------------------------------------------------------- NEW STUFF END
 
 void gameGsCreate(void) {
-  s_pView = viewCreate(0,
-    TAG_VIEW_GLOBAL_PALETTE, 1,
-  TAG_END);
+  s_pView = viewCreate(0, TAG_END);
 
   // Viewport for score bar - on top of screen
   s_pVpScore = vPortCreate(0,

--- a/docs/programming/view.md
+++ b/docs/programming/view.md
@@ -78,7 +78,9 @@ static tSimpleBufferManager *s_pMainBuffer;
 void gameGsCreate(void) {
   // Create a view - first arg is always zero, then it's option-value
   s_pView = viewCreate(0,
-    TAG_VIEW_GLOBAL_PALETTE, 1, // Same Color LookUp Table for all viewports
+    // Same color palette for all viewports, can be skipped as it's set
+    // by default to 1.
+    TAG_VIEW_GLOBAL_PALETTE, 1,
   TAG_END); // Must always end with TAG_END or synonym: TAG_DONE
 
   // Viewport for score bar - on top of screen

--- a/include/ace/managers/viewport/scrollbuffer.h
+++ b/include/ace/managers/viewport/scrollbuffer.h
@@ -73,6 +73,8 @@ typedef struct _tScrollBufferManager {
 	UWORD uwBmAvailHeight;         ///< Avail height of buffer to blit (excludes height reserved for x-scroll)
 	UWORD uwVpHeightPrev;          ///< Prev height of related VPort, used to force refresh on change
 	UWORD uwModulo;                ///< Bitplane modulo
+	UWORD uwDDfStrt;                ///< Display datafetch start
+	UWORD uwDDfStop;                ///< Display datafetch stop
 	UBYTE ubFlags;                 ///< Read only. See SCROLLBUFFER_FLAG_*.
 } tScrollBufferManager;
 

--- a/include/ace/utils/extview.h
+++ b/include/ace/utils/extview.h
@@ -20,12 +20,12 @@ extern "C" {
 #include <ace/managers/memory.h>
 #include <ace/managers/copper.h>
 
-typedef enum _tTagView {
+typedef enum tTagView {
 	// Copperlist mode: raw/block
 	TAG_VIEW_COPLIST_MODE      = TAG_USER | 1,
-	// If in raw mode, specify copperlist instruction count
+	// If in raw mode, specifies copperlist instruction count.
 	TAG_VIEW_COPLIST_RAW_COUNT = TAG_USER | 2,
-	// If set to non-zero, view will use first vport's palette as global & ignore other ones
+	// If set to non-zero, view will use first vport's palette as global & ignore other ones.
 	TAG_VIEW_GLOBAL_PALETTE    = TAG_USER | 3,
 	// The X value for display window start.
 	// TAG_VIEW_WINDOW_START_X    = TAG_USER | 4,
@@ -35,13 +35,17 @@ typedef enum _tTagView {
 	// TAG_VIEW_WINDOW_WIDTH      = TAG_USER | 6,
 	// The height of display window. Defaults to (lastPalScanline - TAG_VIEW_WINDOW_START_Y)
 	TAG_VIEW_WINDOW_HEIGHT     = TAG_USER | 7,
+	// If set to non-zero, view will use first vport's bpp value for whole screen.
+	TAG_VIEW_GLOBAL_BPP        = TAG_USER | 8,
+	// If set to non-zero, view will use first vport's horizontal resolution (hires on/off) setting for whole screen.
+	TAG_VIEW_GLOBAL_HRES       = TAG_USER | 9,
 } tTagView;
 
 // Values for TAG_VIEW_COPLIST_MODE
 #define VIEW_COPLIST_MODE_BLOCK COPPER_MODE_BLOCK
 #define VIEW_COPLIST_MODE_RAW   COPPER_MODE_RAW
 
-typedef enum _tTagVport {
+typedef enum tTagVport {
 	// Ptr to parent view
 	TAG_VPORT_VIEW         = TAG_USER | 1,
 	// vPort dimensions, in pixels
@@ -61,6 +65,8 @@ typedef enum _tTagVport {
 	// manager stuff without letting you including custom instructions in spare
 	// time.
 	TAG_VPORT_OFFSET_TOP   = TAG_USER | 7,
+	// Set to 1 to enable hires mode, set to zero for lores
+	TAG_VPORT_HIRES        = TAG_USER | 8,
 } tTagVport;
 
 /* Types */
@@ -68,13 +74,20 @@ typedef enum _tTagVport {
 /**
  *  View flags.
  */
-#define VIEW_FLAG_GLOBAL_PALETTE 1
-#define VIEW_FLAG_COPLIST_RAW 2
+typedef enum tViewFlags {
+	VIEW_FLAG_GLOBAL_PALETTE = BV(0),
+	VIEW_FLAG_COPLIST_RAW    = BV(1),
+	VIEW_FLAG_GLOBAL_BPP     = BV(2),
+	VIEW_FLAG_GLOBAL_HRES    = BV(3),
+} tViewFlags;
 
 /**
  * Viewport flags.
  */
-#define VIEWPORT_HAS_OWN_PALETTE 1
+typedef enum tVpFlag {
+	VP_FLAG_HAS_OWN_PALETTE = BV(0),
+	VP_FLAG_HIRES           = BV(1),
+} tVpFlag;
 
 /**
  *  Viewport manager IDs.
@@ -90,10 +103,10 @@ typedef enum _tTagVport {
  *  @brief ViewPort manager structure.
  *  Only process and destroy included, each manager has different init params.
  */
-typedef struct _tVpManager {
-	struct _tVpManager *pNext;                      ///< Pointer to next manager.
-	void  (*process)(struct _tVpManager *pManager); ///< Process fn handle.
-	void  (*destroy)(struct _tVpManager *pManager); ///< Destroy fn handle.
+typedef struct tVpManager {
+	struct tVpManager *pNext;                      ///< Pointer to next manager.
+	void  (*process)(struct tVpManager *pManager); ///< Process fn handle.
+	void  (*destroy)(struct tVpManager *pManager); ///< Destroy fn handle.
 	struct _tVPort *pVPort;                         ///< Quick ref to VPort.
 	UBYTE ubId;                                     ///< Manager ID.
 } tVpManager;
@@ -105,11 +118,12 @@ typedef void (*tVpManagerFn)(tVpManager *pManager);
  *  View describes everything what goes to Amiga screen. Each view
  *  is composed of copperlist and viewports.
  */
-typedef struct _tView {
+typedef struct tView {
 	UBYTE ubVpCount;             ///< Viewport count.
 	UWORD uwFlags;               ///< Creation flags.
-	UBYTE ubPosY;               ///< Directly populates the DIWSTRT value.
+	UBYTE ubPosY;                ///< Directly populates the DIWSTRT value.
 	UWORD uwHeight;
+	UWORD uwBplCon0;             ///< Initial/global bplcon0 values.
 	struct _tCopList *pCopList;  ///< Pointer to copperlist.
 	struct _tVPort *pFirstVPort; ///< Pointer to first VPort on list.
 } tView;
@@ -124,7 +138,7 @@ typedef struct _tVPort {
 	tView *pView;              ///< Pointer to parent tView.
 	struct _tVPort *pNext;     ///< Pointer to next tVPort.
 	tVpManager *pFirstManager; ///< Pointer to first viewport manager on list.
-	UWORD uwFlags;             ///< Creation flags.
+	tVpFlag eFlags;             ///< Creation flags.
 
 	// VPort dimensions
 	UWORD uwOffsX;  ///< Viewport's X offset on view.
@@ -133,7 +147,7 @@ typedef struct _tVPort {
 	UWORD uwHeight; ///< Viewport's height
 
 	// Color info
-	UBYTE ubBPP;        ///< Bitplane count
+	UBYTE ubBpp;        ///< Bitplane count
 	UWORD pPalette[32]; ///< Destination palette
 } tVPort;
 
@@ -173,11 +187,11 @@ void viewDestroy(tView *pView);
 void viewProcessManagers(tView *pView);
 
 /**
- *  Updates palette for every viewport attached to view.
+ *  Updates palette for view, if in global palette mode.
  *
- *  @param pView View to be updated.
+ *  @param pView View to use the colors from.
  */
-void viewUpdatePalette(tView *pView);
+void viewUpdateGlobalPalette(const tView *pView);
 
 /**
  *  Sets given view as current and displays it on screen.

--- a/include/ace/utils/palette.h
+++ b/include/ace/utils/palette.h
@@ -25,6 +25,14 @@ extern "C" {
 void paletteLoad(const char *szFileName, UWORD *pPalette, UBYTE ubMaxLength);
 
 /**
+ * @brief Saves given palette into .plt file.
+ * @param pPalette Palette to save.
+ * @param ubColorCnt Number of colors in palette.
+ * @param szPath Destination path.
+ */
+void paletteSave(UWORD *pPalette, UBYTE ubColorCnt, char *szPath);
+
+/**
  * @brief Loads palette from supplied .plt stored in memory to given address.
  * @param pData Palette source pointer.
  * @param pPalette Palette destination pointer.

--- a/showcase/CMakeLists.txt
+++ b/showcase/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 2.8.5)
+cmake_minimum_required(VERSION 3.14)
 project(showcase)
 
 # Lowercase project name for binaries and packaging

--- a/showcase/src/menu/menu.c
+++ b/showcase/src/menu/menu.c
@@ -27,10 +27,7 @@ static UBYTE s_ubMenuType;     /// Current menu list - see MENU_* macros
 void gsMenuCreate(void) {
 	logBlockBegin("gsMenuCreate");
 	// Prepare view & viewport
-	s_pMenuView = viewCreate(0,
-		TAG_VIEW_GLOBAL_PALETTE, 1,
-		TAG_DONE
-	);
+	s_pMenuView = viewCreate(0, TAG_DONE);
 	s_pMenuVPort = vPortCreate(0,
 		TAG_VPORT_VIEW, s_pMenuView,
 		TAG_VPORT_BPP, SHOWCASE_BPP,

--- a/showcase/src/test/blit.c
+++ b/showcase/src/test/blit.c
@@ -22,10 +22,7 @@ static UBYTE (*s_fnKeyPoll)(UBYTE ubKeyCode);
 
 void gsTestBlitCreate(void) {
 	// Prepare view & viewport
-	s_pTestBlitView = viewCreate(0,
-		TAG_VIEW_GLOBAL_PALETTE, 1,
-		TAG_DONE
-	);
+	s_pTestBlitView = viewCreate(0, TAG_DONE);
 	s_pTestBlitVPort = vPortCreate(0,
 		TAG_VPORT_VIEW, s_pTestBlitView,
 		TAG_VPORT_BPP, SHOWCASE_BPP,

--- a/showcase/src/test/blitsmalldest.c
+++ b/showcase/src/test/blitsmalldest.c
@@ -42,10 +42,7 @@ void prepareRefBitmap(void) {
 
 void gsTestBlitSmallDestCreate(void) {
 	// Prepare view & viewport
-	s_pTestBlitView = viewCreate(0,
-		TAG_VIEW_GLOBAL_PALETTE, 1,
-		TAG_DONE
-	);
+	s_pTestBlitView = viewCreate(0, TAG_DONE);
 	s_pTestBlitVPort = vPortCreate(0,
 		TAG_VPORT_VIEW, s_pTestBlitView,
 		TAG_VPORT_BPP, SHOWCASE_BPP,

--- a/showcase/src/test/buffer_scroll.c
+++ b/showcase/src/test/buffer_scroll.c
@@ -35,6 +35,17 @@ static tCameraManager *s_pCamera;
 static tFont *s_pFont;
 static tTextBitMap *s_pTextBitMap;
 
+static void drawModeInfo(tBitMap *pBfr, UWORD uwX, UWORD uwY) {
+	char szMsg[50];
+	sprintf(szMsg, "Current mode is %s", s_pModeNames[s_eCurrentMode]);
+	fontDrawStr(s_pFont, pBfr, uwX, uwY + 0 * 10, szMsg, 6, FONT_COOKIE, s_pTextBitMap);
+	fontDrawStr(s_pFont, pBfr, uwX, uwY + 1 * 10, "WSAD to navigate", 6, FONT_COOKIE, s_pTextBitMap);
+	for(UBYTE i = 0; i < 4; ++i) {
+		sprintf(szMsg, "%d to %s", i + 1, s_pModeNames[i]);
+		fontDrawStr(s_pFont, pBfr, uwX, uwY + (2 + i) * 10, szMsg, 6, FONT_COOKIE, s_pTextBitMap);
+	}
+}
+
 static void fillBfr(tBitMap *pBfr, UWORD uwWidth, UWORD uwHeight) {
 	logBlockBegin(
 		"fillBfr(pBfr: *%p, uwWidth: %hu, uwHeight: %hu)",
@@ -69,15 +80,7 @@ static void fillBfr(tBitMap *pBfr, UWORD uwWidth, UWORD uwHeight) {
 	blitRect(pBfr,       0,        0,       1, uwHeight, 6);
 	blitRect(pBfr, uwWidth,        0,       1, uwHeight, 6);
 
-	char szMsg[50];
-	sprintf(szMsg, "Current mode is %s", s_pModeNames[s_eCurrentMode]);
-	fontDrawStr(s_pFont, pBfr, 100, 50 + 0 * 10, szMsg, 5, FONT_COOKIE, s_pTextBitMap);
-	fontDrawStr(s_pFont, pBfr, 100, 50 + 1 * 10, "WSAD to navigate", 5, FONT_COOKIE, s_pTextBitMap);
-	for(UBYTE i = 0; i < 4; ++i) {
-		sprintf(szMsg, "%d to %s", i + 1, s_pModeNames[i]);
-		fontDrawStr(s_pFont, pBfr, 100, 50 + (2 + i) * 10, szMsg, 5, FONT_COOKIE, s_pTextBitMap);
-	}
-
+	drawModeInfo(pBfr, 50, 50);
 	logBlockEnd("fillBfr()");
 }
 
@@ -128,8 +131,8 @@ static void initScrollBuffer(UBYTE isHires) {
 	tScrollBufferManager *s_pBfr = scrollBufferCreate(0,
 		TAG_SCROLLBUFFER_VPORT, s_pVPort,
 		TAG_SCROLLBUFFER_BITMAP_FLAGS, BMF_CLEAR | BMF_INTERLEAVED,
-		TAG_SCROLLBUFFER_BOUND_WIDTH, 640,
-		TAG_SCROLLBUFFER_BOUND_HEIGHT, 720,
+		TAG_SCROLLBUFFER_BOUND_WIDTH, 1024,
+		TAG_SCROLLBUFFER_BOUND_HEIGHT, 600,
 		TAG_SCROLLBUFFER_MARGIN_WIDTH, 32,
 	TAG_DONE);
 	s_pCamera = s_pBfr->pCamera;
@@ -151,7 +154,10 @@ static void initScrollBuffer(UBYTE isHires) {
 	blitRect(s_pBfr->pBack, 0, 3, 2, 1, ubColor);
 	blitRect(s_pBfr->pBack, 0, 4, 1, 1, ubColor);
 
-	blitRect(s_pBfr->pBack, 32, 32, 32, 32, 5);
+	blitRect(s_pBfr->pBack, 16, 16, 32, 32, 5);
+
+	drawModeInfo(s_pBfr->pBack, 50, 50);
+
 	viewLoad(s_pView);
 	systemUnuse();
 }

--- a/showcase/src/test/buffer_scroll.c
+++ b/showcase/src/test/buffer_scroll.c
@@ -8,13 +8,32 @@
 #include <ace/managers/viewport/scrollbuffer.h>
 #include <ace/managers/viewport/simplebuffer.h>
 #include <ace/utils/palette.h>
+#include <ace/utils/font.h>
 #include "game.h"
 
-#define TEST_SCROLL_BPP 6
+#define TEST_SCROLL_BPP 4
 
+typedef enum tMode {
+	MODE_SIMPLE_LORES,
+	MODE_SIMPLE_HIRES,
+	MODE_SCROLL_LORES,
+	MODE_SCROLL_HIRES,
+	MODE_COUNT
+} tMode;
+
+static const char *s_pModeNames[MODE_COUNT] = {
+	[MODE_SIMPLE_LORES] = "lores simplebuffer",
+	[MODE_SIMPLE_HIRES] = "hires simplebuffer",
+	[MODE_SCROLL_LORES] = "lores scrollbuffer",
+	[MODE_SCROLL_HIRES] = "hires scrollbuffer",
+};
+
+static tMode s_eCurrentMode;
 static tView *s_pView;
 static tVPort *s_pVPort;
 static tCameraManager *s_pCamera;
+static tFont *s_pFont;
+static tTextBitMap *s_pTextBitMap;
 
 static void fillBfr(tBitMap *pBfr, UWORD uwWidth, UWORD uwHeight) {
 	logBlockBegin(
@@ -49,10 +68,20 @@ static void fillBfr(tBitMap *pBfr, UWORD uwWidth, UWORD uwHeight) {
 	blitRect(pBfr,       0, uwHeight, uwWidth,        1, 6);
 	blitRect(pBfr,       0,        0,       1, uwHeight, 6);
 	blitRect(pBfr, uwWidth,        0,       1, uwHeight, 6);
+
+	char szMsg[50];
+	sprintf(szMsg, "Current mode is %s", s_pModeNames[s_eCurrentMode]);
+	fontDrawStr(s_pFont, pBfr, 100, 50 + 0 * 10, szMsg, 5, FONT_COOKIE, s_pTextBitMap);
+	fontDrawStr(s_pFont, pBfr, 100, 50 + 1 * 10, "WSAD to navigate", 5, FONT_COOKIE, s_pTextBitMap);
+	for(UBYTE i = 0; i < 4; ++i) {
+		sprintf(szMsg, "%d to %s", i + 1, s_pModeNames[i]);
+		fontDrawStr(s_pFont, pBfr, 100, 50 + (2 + i) * 10, szMsg, 5, FONT_COOKIE, s_pTextBitMap);
+	}
+
 	logBlockEnd("fillBfr()");
 }
 
-void initSimple(void) {
+static void initSimpleBuffer(UBYTE isHires, UWORD uwWidth, UWORD uwHeight) {
 	viewLoad(0);
 	systemUse();
 	if(s_pView->pFirstVPort) {
@@ -62,24 +91,25 @@ void initSimple(void) {
 	s_pVPort = vPortCreate(0,
 		TAG_VPORT_VIEW, s_pView,
 		TAG_VPORT_BPP, TEST_SCROLL_BPP,
+		TAG_VPORT_HIRES, isHires,
 	TAG_DONE);
 	paletteLoad("data/amidb32.plt", s_pVPort->pPalette, 1 << SHOWCASE_BPP);
 
 	tSimpleBufferManager *s_pBfr = simpleBufferCreate(0,
 		TAG_SIMPLEBUFFER_VPORT, s_pVPort,
 		TAG_SIMPLEBUFFER_BITMAP_FLAGS, BMF_CLEAR | BMF_INTERLEAVED,
-		TAG_SIMPLEBUFFER_BOUND_WIDTH, 640,
-		TAG_SIMPLEBUFFER_BOUND_HEIGHT, 720,
+		TAG_SIMPLEBUFFER_BOUND_WIDTH, uwWidth,
+		TAG_SIMPLEBUFFER_BOUND_HEIGHT, uwHeight,
 	TAG_DONE);
 	s_pCamera = s_pBfr->pCamera;
 
-	fillBfr(s_pBfr->pBack, 640, 720);
+	fillBfr(s_pBfr->pBack, uwWidth, uwHeight);
 
 	viewLoad(s_pView);
 	systemUnuse();
 }
 
-void initScroll(void) {
+static void initScrollBuffer(UBYTE isHires) {
 	viewLoad(0);
 	systemUse();
 	if(s_pView->pFirstVPort) {
@@ -89,6 +119,7 @@ void initScroll(void) {
 	s_pVPort = vPortCreate(0,
 		TAG_VPORT_VIEW, s_pView,
 		TAG_VPORT_BPP, TEST_SCROLL_BPP,
+		TAG_VPORT_HIRES, isHires,
 	TAG_DONE);
 	paletteLoad("data/amidb32.plt", s_pVPort->pPalette, 1 << SHOWCASE_BPP);
 
@@ -125,14 +156,36 @@ void initScroll(void) {
 	systemUnuse();
 }
 
+static void changeMode(tMode eMode) {
+	s_eCurrentMode = eMode;
+	switch(eMode) {
+		case MODE_SIMPLE_LORES:
+			initSimpleBuffer(0, 400, 300);
+			break;
+		case MODE_SIMPLE_HIRES:
+			initSimpleBuffer(1, 720, 300);
+			break;
+		case MODE_SCROLL_LORES:
+			initScrollBuffer(0);
+			break;
+		case MODE_SCROLL_HIRES:
+			initScrollBuffer(1);
+			break;
+		default:
+			break;
+	}
+}
+
 void gsTestBufferScrollCreate(void) {
 	logBlockBegin("gsTestBufferScrollCreate()");
 
 	s_pView = viewCreate(0,
-		TAG_VIEW_GLOBAL_PALETTE, 1,
 	TAG_DONE);
 
-	initScroll();
+	s_pFont = fontCreate("data/fonts/silkscreen.fnt");
+	s_pTextBitMap = fontCreateTextBitMap(320, s_pFont->uwHeight);
+	s_eCurrentMode = MODE_SIMPLE_LORES;
+	changeMode(s_eCurrentMode);
 	logBlockEnd("gsTestBufferScrollCreate()");
 	systemUnuse();
 }
@@ -158,10 +211,16 @@ void gsTestBufferScrollLoop(void) {
 	}
 
 	if(keyUse(KEY_1)) {
-		initSimple();
+		changeMode(MODE_SIMPLE_LORES);
 	}
 	else if(keyUse(KEY_2)) {
-		initScroll();
+		changeMode(MODE_SIMPLE_HIRES);
+	}
+	else if(keyUse(KEY_3)) {
+		changeMode(MODE_SCROLL_LORES);
+	}
+	else if(keyUse(KEY_4)) {
+		changeMode(MODE_SCROLL_HIRES);
 	}
 
 	cameraMoveBy(s_pCamera, wDx, wDy);
@@ -174,5 +233,9 @@ void gsTestBufferScrollDestroy(void) {
 	logBlockBegin("gsTestBufferScrollDestroy()");
 	systemUse();
 	viewDestroy(s_pView);
+
+	fontDestroy(s_pFont);
+	fontDestroyTextBitMap(s_pTextBitMap);
+
 	logBlockEnd("gsTestBufferScrollDestroy()");
 }

--- a/showcase/src/test/copper.c
+++ b/showcase/src/test/copper.c
@@ -78,7 +78,6 @@ void gsTestCopperCreate(void) {
 	}
 
 	s_pTestCopperView = viewCreate(0,
-		TAG_VIEW_GLOBAL_PALETTE, 1,
 		TAG_VIEW_COPLIST_MODE, ulMode,         // <-- This is important in RAW mode
 		TAG_VIEW_COPLIST_RAW_COUNT, ulRawSize, // <-- This is important in RAW mode
 		TAG_DONE

--- a/showcase/src/test/font.c
+++ b/showcase/src/test/font.c
@@ -24,10 +24,7 @@ static UBYTE s_ubPage;
 
 void gsTestFontCreate(void) {
 	// Prepare view & viewport
-	s_pTestFontView = viewCreate(0,
-		TAG_VIEW_GLOBAL_PALETTE, 1,
-		TAG_DONE
-	);
+	s_pTestFontView = viewCreate(0, TAG_DONE);
 	s_pTestFontVPort = vPortCreate(0,
 		TAG_VPORT_VIEW, s_pTestFontView,
 		TAG_VPORT_BPP, SHOWCASE_BPP,

--- a/showcase/src/test/input.c
+++ b/showcase/src/test/input.c
@@ -123,10 +123,7 @@ static void showParallelStatus(void) {
 
 void gsTestInputCreate(void) {
 	// Prepare view & viewport
-	s_pTestInputView = viewCreate(0,
-		TAG_VIEW_GLOBAL_PALETTE, 1,
-		TAG_DONE
-	);
+	s_pTestInputView = viewCreate(0, TAG_DONE);
 	s_pTestInputVPort = vPortCreate(0,
 		TAG_VPORT_VIEW, s_pTestInputView,
 		TAG_VPORT_BPP, SHOWCASE_BPP,

--- a/showcase/src/test/interleaved.c
+++ b/showcase/src/test/interleaved.c
@@ -25,10 +25,7 @@ static WORD wX, wY;
 static BYTE bDx, bDy;
 
 void gsTestInterleavedCreate(void) {
-	s_pTestInterleavedView = viewCreate(0,
-		TAG_VIEW_GLOBAL_PALETTE, 1,
-		TAG_DONE
-	);
+	s_pTestInterleavedView = viewCreate(0, TAG_DONE);
 	s_pTestInterleavedVPort = vPortCreate(0,
 		TAG_VPORT_VIEW, s_pTestInterleavedView,
 		TAG_VPORT_BPP, SHOWCASE_BPP,

--- a/showcase/src/test/lines.c
+++ b/showcase/src/test/lines.c
@@ -16,10 +16,7 @@ static tVPort *s_pVPort;
 static tSimpleBufferManager *s_pBfrManager;
 
 void gsTestLinesCreate(void) {
-	s_pView = viewCreate(0,
-		TAG_VIEW_GLOBAL_PALETTE, 1,
-		TAG_END
-	);
+	s_pView = viewCreate(0, TAG_END);
 	s_pVPort = vPortCreate(0,
 		TAG_VPORT_BPP, 4,
 		TAG_VPORT_VIEW, s_pView,

--- a/showcase/src/test/twister.c
+++ b/showcase/src/test/twister.c
@@ -48,10 +48,7 @@ static void testGrid(UBYTE ubSize) {
 
 void gsTestTwisterCreate(void) {
 	// Prepare view & viewport
-	s_pView = viewCreate(0,
-		TAG_VIEW_GLOBAL_PALETTE, 1,
-		TAG_DONE
-	);
+	s_pView = viewCreate(0, TAG_DONE);
 	s_pVPort = vPortCreate(0,
 		TAG_VPORT_VIEW, s_pView,
 		TAG_VPORT_BPP, 2,

--- a/src/ace/managers/viewport/simplebuffer.c
+++ b/src/ace/managers/viewport/simplebuffer.c
@@ -38,19 +38,32 @@ static void simpleBufferInitializeCopperList(
 	pManager->uBfrBounds.uwX = bitmapGetByteWidth(pManager->pFront) << 3;
 	pManager->uBfrBounds.uwY = pManager->pFront->Rows;
 	UWORD uwModulo = pManager->pFront->BytesPerRow - (pManager->sCommon.pVPort->uwWidth >> 3);
-	UWORD uwDDfStrt;
+
+	// http://amigadev.elowar.com/read/ADCD_2.1/Hardware_Manual_guide/node0085.html
+	UWORD uwDDfStrt = 0x0038;
+	UWORD uwDDfStop = 0x00D0;
+	if(pManager->sCommon.pVPort->eFlags & VP_FLAG_HIRES) {
+		uwDDfStrt += 4;
+		uwDDfStop += 4;
+	}
+
 	if(
 		!isScrollX || pManager->uBfrBounds.uwX <= pManager->sCommon.pVPort->uwWidth
 	) {
-		uwDDfStrt = 0x0038;
 		pManager->ubFlags &= ~SIMPLEBUFFER_FLAG_X_SCROLLABLE;
 	}
 	else {
 		pManager->ubFlags |= SIMPLEBUFFER_FLAG_X_SCROLLABLE;
-		uwDDfStrt = 0x0030;
-		uwModulo -= 2;
+		if(pManager->sCommon.pVPort->eFlags & VP_FLAG_HIRES) {
+			uwDDfStrt -= 8; // two more hires 4-part bitplane fetch pattern: 3120
+			uwModulo -= 4;
+		}
+		else {
+			uwDDfStrt -= 8; // one more lores 8-part bitplane fetch pattern: x351x240
+			uwModulo -= 2;
+		}
 	}
-	logWrite("Modulo: %u\n", uwModulo);
+	logWrite("DDFSTRT: %04X, DDFSTOP: %04X, Modulo: %u\n", uwDDfStrt, uwDDfStop, uwModulo);
 
 	// Update (rewrite) copperlist
 	// TODO this could be unified with copBlock being set with copSetMove too
@@ -64,11 +77,11 @@ static void simpleBufferInitializeCopperList(
 			"Setting copperlist %p at offs %u\n",
 			pCopList->pBackBfr, pManager->uwCopperOffset
 		);
-		copSetWait(&pCmdList[0].sWait, s_pCopperWaitXByBitplanes[pManager->sCommon.pVPort->ubBPP], (
+		copSetWait(&pCmdList[0].sWait, s_pCopperWaitXByBitplanes[pManager->sCommon.pVPort->ubBpp], (
 			pManager->sCommon.pVPort->uwOffsY +
 			pManager->sCommon.pVPort->pView->ubPosY -1
 		));
-		copSetMove(&pCmdList[1].sMove, &g_pCustom->ddfstop, 0x00D0);    // Data fetch
+		copSetMove(&pCmdList[1].sMove, &g_pCustom->ddfstop, uwDDfStop);    // Data fetch
 		copSetMove(&pCmdList[2].sMove, &g_pCustom->ddfstrt, uwDDfStrt);
 		copSetMove(&pCmdList[3].sMove, &g_pCustom->bpl1mod, uwModulo);  // Bitplane modulo
 		copSetMove(&pCmdList[4].sMove, &g_pCustom->bpl2mod, uwModulo);
@@ -82,7 +95,12 @@ static void simpleBufferInitializeCopperList(
 		// if X scroll is enabled then it needs to start one word early
 		ULONG ulBplOffs = 0;
 		if(pManager->ubFlags & SIMPLEBUFFER_FLAG_X_SCROLLABLE) {
-			ulBplOffs = -2;
+			if(pManager->sCommon.pVPort->eFlags & VP_FLAG_HIRES) {
+				ulBplOffs = -4;
+			}
+			else {
+				ulBplOffs = -2;
+			}
 		}
 
 		// Proper back buffer pointers
@@ -100,7 +118,7 @@ static void simpleBufferInitializeCopperList(
 		copMove(pCopList, pBlock, &g_pCustom->bpl1mod, uwModulo);   // Bitplane modulo
 		copMove(pCopList, pBlock, &g_pCustom->bpl2mod, uwModulo);
 		copMove(pCopList, pBlock, &g_pCustom->bplcon1, 0);          // Shift: 0
-		for (UBYTE i = 0; i < pManager->sCommon.pVPort->ubBPP; ++i) {
+		for (UBYTE i = 0; i < pManager->sCommon.pVPort->ubBpp; ++i) {
 			ULONG ulPlaneAddr = (ULONG)pManager->pBack->Planes[i];
 			copMove(pCopList, pBlock, &g_pBplFetch[i].uwHi, ulPlaneAddr >> 16);
 			copMove(pCopList, pBlock, &g_pBplFetch[i].uwLo, ulPlaneAddr & 0xFFFF);
@@ -122,9 +140,13 @@ static UWORD simpleBufferCalcBplOffsAndShift(tSimpleBufferManager *pManager, ULO
 	// Calculate X movement: bitplane shift, starting word to fetch
 	UWORD uwShift;
 	if(pManager->ubFlags & SIMPLEBUFFER_FLAG_X_SCROLLABLE) {
-		uwShift = (16 - (pManager->pCamera->uPos.uwX & 0xF)) & 0xF;  // Bitplane shift - single
-		uwShift = (uwShift << 4) | uwShift;                // Bitplane shift - PF1 | PF2
-		*pBplOffs = ((pManager->pCamera->uPos.uwX - 1) >> 4) << 1;   // Must be ULONG!
+		uwShift = (16 - (pManager->pCamera->uPos.uwX & 0xF)) & 0xF; // Bitplane shift - single
+		*pBplOffs = ((pManager->pCamera->uPos.uwX - 1) >> 4) << 1;  // Must be ULONG!
+		if(pManager->sCommon.pVPort->eFlags & VP_FLAG_HIRES) {
+			uwShift >>= 1; // Usable scroll values are 0..7, shifts 2 pixels per value
+			*pBplOffs -= 2; // Fetch 4 bytes (2 words) in scrolling instead of 2 (4)
+		}
+		uwShift = (uwShift << 4) | uwShift; // Convert to bplcon format - PF1 | PF2
 	}
 	else {
 		uwShift = 0;
@@ -190,7 +212,7 @@ tSimpleBufferManager *simpleBufferCreate(void *pTags, ...) {
 	);
 	logWrite("Bounds: %ux%u\n", uwBoundWidth, uwBoundHeight);
 	pFront = bitmapCreate(
-		uwBoundWidth, uwBoundHeight, pVPort->ubBPP, ubBitmapFlags
+		uwBoundWidth, uwBoundHeight, pVPort->ubBpp, ubBitmapFlags
 	);
 	if(!pFront) {
 		logWrite("ERR: Can't alloc buffer bitmap!\n");
@@ -200,7 +222,7 @@ tSimpleBufferManager *simpleBufferCreate(void *pTags, ...) {
 	UBYTE isDblBfr = tagGet(pTags, vaTags, TAG_SIMPLEBUFFER_IS_DBLBUF, 0);
 	if(isDblBfr) {
 		pBack = bitmapCreate(
-			uwBoundWidth, uwBoundHeight, pVPort->ubBPP, ubBitmapFlags
+			uwBoundWidth, uwBoundHeight, pVPort->ubBpp, ubBitmapFlags
 		);
 		if(!pBack) {
 			logWrite("ERR: Can't alloc buffer bitmap!\n");
@@ -222,10 +244,10 @@ tSimpleBufferManager *simpleBufferCreate(void *pTags, ...) {
 		// CopBlock contains: bitplanes + shiftX
 		pManager->pCopBlock = copBlockCreate(
 			// WAIT is already in copBlock so 1 instruction less
-			pCopList, simpleBufferGetRawCopperlistInstructionCount(pVPort->ubBPP) - 1,
+			pCopList, simpleBufferGetRawCopperlistInstructionCount(pVPort->ubBpp) - 1,
 			// Vertically addition from DiWStrt, horizontally just so that 6bpp can be set up.
 			// First to set are ddf, modulos & shift so they are changed during fetch.
-			s_pCopperWaitXByBitplanes[pVPort->ubBPP],
+			s_pCopperWaitXByBitplanes[pVPort->ubBpp],
 			 pVPort->uwOffsY + pVPort->pView->ubPosY - 1
 		);
 	}

--- a/src/ace/managers/viewport/tilebuffer.c
+++ b/src/ace/managers/viewport/tilebuffer.c
@@ -48,11 +48,17 @@ static void tileBufferQueueAdd(
 	}
 #endif
 	tRedrawState *pState = &pManager->pRedrawStates[0];
+	if(pState->ubPendingCount >= pManager->ubQueueSize) {
+		logWrite("ERR: Pending tiles queue overflow!");
+	}
 	pState->pPendingQueue[pState->ubPendingCount].uwX = uwTileX;
 	pState->pPendingQueue[pState->ubPendingCount].uwY = uwTileY;
 	++pState->ubPendingCount;
 
 	pState = &pManager->pRedrawStates[1];
+	if(pState->ubPendingCount >= pManager->ubQueueSize) {
+		logWrite("ERR: Pending tiles queue overflow!");
+	}
 	pState->pPendingQueue[pState->ubPendingCount].uwX = uwTileX;
 	pState->pPendingQueue[pState->ubPendingCount].uwY = uwTileY;
 	++pState->ubPendingCount;

--- a/src/ace/managers/viewport/tilebuffer.c
+++ b/src/ace/managers/viewport/tilebuffer.c
@@ -624,6 +624,24 @@ void tileBufferRedrawAll(tTileBufferManager *pManager) {
 		}
 		uwTileOffsY = (uwTileOffsY + ubTileSize) & (pManager->uwMarginedHeight - 1);
 	}
+
+	if (pManager->cbTileDraw) {
+		uwTileOffsY = (wStartY << ubTileShift) & (pManager->uwMarginedHeight - 1);
+		for (UWORD uwTileY = wStartY; uwTileY < uwEndY; ++uwTileY) {
+			uwTileOffsX = (wStartX << ubTileShift);
+			UWORD uwTileCurr = wStartX;
+			while (uwTileCurr < uwEndX) {
+				pManager->cbTileDraw(
+					uwTileCurr, uwTileY, pManager->pScroll->pBack,
+					uwTileOffsX, uwTileOffsY
+				);
+				++uwTileCurr;
+				uwTileOffsX += ubTileSize;
+			}
+			uwTileOffsY = (uwTileOffsY + ubTileSize) & (pManager->uwMarginedHeight - 1);
+		}
+	}
+
 	systemSetDmaBit(DMAB_BLITHOG, 0);
 
 	// Copy from back buffer to front buffer.

--- a/src/ace/utils/bitmap.c
+++ b/src/ace/utils/bitmap.c
@@ -133,6 +133,13 @@ void bitmapLoadFromFile(
 		"bitmapLoadFromFile(pBitMap: %p, szFilePath: '%s', uwStartX: %u, uwStartY: %u)",
 		pBitMap, szFilePath, uwStartX, uwStartY
 	);
+
+	if(!pBitMap) {
+		logWrite("ERR: pBitMap is 0\n");
+		systemUnuse();
+		return;
+	}
+
 	// Open source bitmap
 	tFile *pFile = fileOpen(szFilePath, "r");
 	if(!pFile) {

--- a/src/ace/utils/bitmap.c
+++ b/src/ace/utils/bitmap.c
@@ -209,14 +209,23 @@ void bitmapLoadFromFile(
 	UWORD uwReadBytesPerRow = (uwSrcWidth + 7) / 8;
 	if(bitmapIsInterleaved(pBitMap)) {
 		UWORD uwDestOffs = uwWidth * (uwStartY * pBitMap->Depth) + (uwStartX / 8);
-		for(y = 0; y < uwSrcHeight; ++y) {
-			for(ubPlane = 0; ubPlane != pBitMap->Depth; ++ubPlane) {
-				fileRead(
-					pFile,
-					&pBitMap->Planes[0][uwDestOffs],
-					uwReadBytesPerRow
-				);
-				uwDestOffs += uwWidth;
+		if(uwStartX == 0 && uwSrcWidth == uwDstWidth) {
+			fileRead(
+				pFile,
+				&pBitMap->Planes[0][uwDestOffs],
+				pBitMap->BytesPerRow * uwSrcHeight
+			);
+		}
+		else {
+			for(y = 0; y < uwSrcHeight; ++y) {
+				for(ubPlane = 0; ubPlane != pBitMap->Depth; ++ubPlane) {
+					fileRead(
+						pFile,
+						&pBitMap->Planes[0][uwDestOffs],
+						uwReadBytesPerRow
+					);
+					uwDestOffs += uwWidth;
+				}
 			}
 		}
 	}

--- a/src/ace/utils/bitmap.c
+++ b/src/ace/utils/bitmap.c
@@ -206,25 +206,30 @@ void bitmapLoadFromFile(
 
 	// Read data
 	uwWidth = bitmapGetByteWidth(pBitMap);
+	UWORD uwReadBytesPerRow = (uwSrcWidth + 7) / 8;
 	if(bitmapIsInterleaved(pBitMap)) {
-		for(y = 0; y != uwSrcHeight; ++y) {
+		UWORD uwDestOffs = uwWidth * (uwStartY * pBitMap->Depth) + (uwStartX / 8);
+		for(y = 0; y < uwSrcHeight; ++y) {
 			for(ubPlane = 0; ubPlane != pBitMap->Depth; ++ubPlane) {
 				fileRead(
 					pFile,
-					&pBitMap->Planes[0][uwWidth*(((uwStartY + y)*pBitMap->Depth)+ubPlane)+(uwStartX>>3)],
-					((uwSrcWidth+7)>>3)
+					&pBitMap->Planes[0][uwDestOffs],
+					uwReadBytesPerRow
 				);
+				uwDestOffs += uwWidth;
 			}
 		}
 	}
 	else {
 		for(ubPlane = 0; ubPlane != pBitMap->Depth; ++ubPlane) {
 			for(y = 0; y != uwSrcHeight; ++y) {
+				UWORD uwDestOffs = uwWidth * uwStartY + (uwStartX / 8);
 				fileRead(
 					pFile,
-					&pBitMap->Planes[ubPlane][uwWidth*(uwStartY+y) + (uwStartX>>3)],
-					((uwSrcWidth+7)>>3)
+					&pBitMap->Planes[ubPlane][uwDestOffs],
+					uwReadBytesPerRow
 				);
+				uwDestOffs += uwWidth;
 			}
 		}
 	}

--- a/src/ace/utils/extview.c
+++ b/src/ace/utils/extview.c
@@ -41,11 +41,22 @@ tView *viewCreate(void *pTags, ...) {
 		pView->pCopList = copListCreate(0, TAG_DONE);
 	}
 
-	// Additional palette tags
-	if(tagGet(pTags, vaTags, TAG_VIEW_GLOBAL_PALETTE, 0)) {
+	// Global display mode tags
+	if(tagGet(pTags, vaTags, TAG_VIEW_GLOBAL_PALETTE, 1)) {
 		pView->uwFlags |= VIEW_FLAG_GLOBAL_PALETTE;
-		logWrite("Global palette mode enabled\n");
 	}
+	if(tagGet(pTags, vaTags, TAG_VIEW_GLOBAL_HRES, 1)) {
+		pView->uwFlags |= VIEW_FLAG_GLOBAL_HRES;
+	}
+	if(tagGet(pTags, vaTags, TAG_VIEW_GLOBAL_BPP, 1)) {
+		pView->uwFlags |= VIEW_FLAG_GLOBAL_BPP;
+	}
+	logWrite(
+		"Extra flags: %s%s%s\n",
+		(pView->uwFlags & VIEW_FLAG_GLOBAL_PALETTE) ? "GLOBAL_PALETTE " : "",
+		(pView->uwFlags & VIEW_FLAG_GLOBAL_BPP) ? "GLOBAL_BPP " : "",
+		(pView->uwFlags & VIEW_FLAG_GLOBAL_HRES) ? "GLOBAL_HRES " : ""
+	);
 
 	// Get the Y pos and height
 	const UWORD uwDefaultHeight = -1;
@@ -138,15 +149,12 @@ void viewProcessManagers(tView *pView) {
 	}
 }
 
-void viewUpdatePalette(tView *pView) {
+void viewUpdateGlobalPalette(const tView *pView) {
 #ifdef AMIGA
 	if(pView->uwFlags & VIEW_FLAG_GLOBAL_PALETTE) {
 		for(UBYTE i = 0; i < 32; ++i) {
 			g_pCustom->color[i] = pView->pFirstVPort->pPalette[i];
 		}
-	}
-	else {
-		// na petli: vPortUpdatePalette();
 	}
 #endif // AMIGA
 }
@@ -190,10 +198,19 @@ void viewLoad(tView *pView) {
 			}
 		}
 #endif
+		pView->uwBplCon0 = 0;
+		if(pView->uwFlags & VIEW_FLAG_GLOBAL_BPP) {
+			pView->uwBplCon0 |= pView->pFirstVPort->ubBpp << 12;
+		}
+		if(pView->uwFlags & VIEW_FLAG_GLOBAL_HRES) {
+			pView->uwBplCon0 |= ((pView->pFirstVPort->eFlags & VP_FLAG_HIRES) != 0) << 15;
+		}
+		pView->uwBplCon0 |= BV(9); // composite output
+
 		g_sCopManager.pCopList = pView->pCopList;
-		g_pCustom->bplcon0 = (pView->pFirstVPort->ubBPP << 12) | BV(9); // BPP + composite output
-		g_pCustom->fmode = 0;        // AGA fix
-		g_pCustom->bplcon3 = 0;      // AGA fix
+		g_pCustom->bplcon0 = pView->uwBplCon0; // BPP + composite output
+		g_pCustom->fmode = 0; // AGA fix
+		g_pCustom->bplcon3 = 0; // AGA fix
 		g_pCustom->diwstrt = (pView->ubPosY << 8) | 0x81; // HSTART: 0x81
 		UWORD uwDiwStopY = pView->ubPosY + pView->uwHeight;
 		if(BTST(uwDiwStopY, 8) == BTST(uwDiwStopY, 7)) {
@@ -203,7 +220,7 @@ void viewLoad(tView *pView) {
 			);
 		}
 		g_pCustom->diwstop = ((uwDiwStopY & 0xFF) << 8) | 0xC1; // HSTOP: 0xC1
-		viewUpdatePalette(pView);
+		viewUpdateGlobalPalette(pView);
 	}
 	copProcessBlocks();
 	g_pCustom->copjmp1 = 1;
@@ -235,10 +252,6 @@ tVPort *vPortCreate(void *pTagList, ...) {
 	pVPort->pView = pView;
 	logWrite("Parent view: %p\n", pView);
 
-	const UWORD uwDefaultWidth = s_isPAL ? SCREEN_PAL_WIDTH : SCREEN_NTSC_WIDTH;
-	const UWORD uwDefaultHeight = -1;
-	const UWORD uwDefaultBpp = 4; // 'Cuz copper is slower @ 5bpp & more in OCS
-
 	// Calculate Y offset - beneath previous ViewPort
 	pVPort->uwOffsY = 0;
 	tVPort *pPrevVPort = pView->pFirstVPort;
@@ -253,15 +266,32 @@ tVPort *vPortCreate(void *pTagList, ...) {
 	pVPort->uwOffsY += ulAddOffsY;
 	logWrite("Offsets: %ux%u\n", pVPort->uwOffsX, pVPort->uwOffsY);
 
+	if(
+		tagGet(pTagList, vaTags, TAG_VPORT_HIRES, 0) ||
+		((pView->uwFlags & VIEW_FLAG_GLOBAL_HRES) && pPrevVPort && pPrevVPort->eFlags & VP_FLAG_HIRES)
+	) {
+		pVPort->eFlags |= VP_FLAG_HIRES;
+	}
+	const UWORD uwDefaultBpp = 4; // 'Cuz copper is slower on 5bpp+ in OCS
+	pVPort->ubBpp = tagGet(pTagList, vaTags, TAG_VPORT_BPP, uwDefaultBpp);
+
 	// Get dimensions
+	UWORD uwDefaultWidth = s_isPAL ? SCREEN_PAL_WIDTH : SCREEN_NTSC_WIDTH;
+	if(pVPort->eFlags & VP_FLAG_HIRES) {
+		uwDefaultWidth *= 2;
+	}
+	const UWORD uwDefaultHeight = -1;
+
 	pVPort->uwWidth = tagGet(pTagList, vaTags, TAG_VPORT_WIDTH, uwDefaultWidth);
 	pVPort->uwHeight = tagGet(pTagList, vaTags, TAG_VPORT_HEIGHT, uwDefaultHeight);
 	if(pVPort->uwHeight == uwDefaultHeight) {
 		pVPort->uwHeight = pView->uwHeight - pVPort->uwOffsY;
 	}
-	pVPort->ubBPP = tagGet(pTagList, vaTags, TAG_VPORT_BPP, uwDefaultBpp);
+
 	logWrite(
-		"Dimensions: %ux%u@%hu\n", pVPort->uwWidth, pVPort->uwHeight, pVPort->ubBPP
+		"Dimensions: %ux%u@%hu (%s)\n",
+		pVPort->uwWidth, pVPort->uwHeight, pVPort->ubBpp,
+		((pVPort->eFlags & VP_FLAG_HIRES) ? "HIRES" : "LORES")
 	);
 
 	// Update view - add to vPort list
@@ -366,7 +396,7 @@ void vPortUpdatePalette(tVPort *pVPort) {
 	// (like expanding HUD to fullscreen like we did in Goblin Villages).
 	// On copblocks implementing it is somewhat easy, but on raw copperlist
 	// something clever must be done.
-	if(pVPort->uwFlags & VIEWPORT_HAS_OWN_PALETTE) {
+	if(pVPort->eFlags & VP_FLAG_HAS_OWN_PALETTE) {
 		logWrite("TODO: implement vPortUpdatePalette!\n");
 	}
 }

--- a/src/ace/utils/palette.c
+++ b/src/ace/utils/palette.c
@@ -84,3 +84,27 @@ void paletteDump(UWORD *pPalette, UBYTE ubColorCnt, char *szPath) {
 	bitmapSaveBmp(pBm, pPalette, szPath);
 	bitmapDestroy(pBm);
 }
+
+void paletteSave(UWORD *pPalette, UBYTE ubColorCnt, char *szPath) {
+	tFile *pFile;
+	UBYTE ubPaletteLength;
+
+	logBlockBegin(
+		"paletteSave(pPalette: %p, ubColorCnt: %hu, szPath: '%s')",
+		pPalette, ubColorCnt, szPath
+	);
+
+	pFile = fileOpen(szPath, "wb");
+	if(!pFile) {
+		logWrite("ERR: Can't write file!\n");
+		logBlockEnd("paletteSave()");
+		return;
+	}
+	else {
+		fileWrite(pFile, &ubColorCnt, sizeof(UBYTE));
+		fileWrite(pFile, pPalette, sizeof(UWORD) * ubColorCnt);
+		fileClose(pFile);
+	}
+
+	logBlockEnd("paletteSave()");
+}

--- a/tools/CMakeLists.txt
+++ b/tools/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 3.0.0)
+cmake_minimum_required(VERSION 3.14.0)
 # Generator expression skips Debug/Release/... directories for MSVC
 set(CMAKE_RUNTIME_OUTPUT_DIRECTORY ${CMAKE_CURRENT_SOURCE_DIR}/bin/$<0:>)
 project(ACE_tools)

--- a/tools/src/audio_conv.cpp
+++ b/tools/src/audio_conv.cpp
@@ -105,7 +105,7 @@ int main(int lArgCount, const char *pArgs[]) {
 	}
 
 	if(szOutput.empty()) {
-		szOutput = nFs::trimExt(szInput);
+		szOutput = nFs::removeExt(szInput);
 		if(szInExt == "wav") {
 			szOutput += ".sfx";
 		}
@@ -161,7 +161,7 @@ int main(int lArgCount, const char *pArgs[]) {
 		fmt::print("Splitting to {} parts, {} bytes each\n", PartCount, oSplitAfter.value());
 		std::uint8_t ubPart = 0;
 		tSfx SfxRemaining;
-		auto BaseOutputPath = nFs::trimExt(szOutput);
+		auto BaseOutputPath = nFs::removeExt(szOutput);
 		do {
 			SfxRemaining = In.splitAfter(oSplitAfter.value());
 			auto PartOutPath = fmt::format(FMT_STRING("{}_{}.{}"), BaseOutputPath, ubPart, szOutExt);

--- a/tools/src/bitmap_conv.cpp
+++ b/tools/src/bitmap_conv.cpp
@@ -85,7 +85,7 @@ int main(int lArgCount, const char *pArgs[])
 		return EXIT_FAILURE;
 	}
 	if(szOutput.empty()) {
-		szOutput = nFs::trimExt(szInput);
+		szOutput = nFs::removeExt(szInput);
 		if(szInExt == "png") {
 			szOutput += ".bm";
 		}
@@ -97,10 +97,10 @@ int main(int lArgCount, const char *pArgs[])
 
 	if(szMask == "" && isMaskColor) {
 		if(szOutExt == "bm") {
-			szMask = nFs::trimExt(szOutput) + "_mask." + szOutExt;
+			szMask = nFs::removeExt(szOutput) + "_mask." + szOutExt;
 		}
 		else if(szInExt == "bm") {
-			szMask = nFs::trimExt(szInput) + "_mask." + szInExt;
+			szMask = nFs::removeExt(szInput) + "_mask." + szInExt;
 		}
 	}
 
@@ -131,7 +131,7 @@ int main(int lArgCount, const char *pArgs[])
 			for(std::uint16_t i = 1; i < 256; ++i) {
 				PaletteMask.m_vColors.push_back(MaskColor);
 			}
-			auto szInMask = nFs::trimExt(szInput) + "_mask." + szInExt;
+			auto szInMask = nFs::removeExt(szInput) + "_mask." + szInExt;
 			auto InMask = tChunkyBitmap(tPlanarBitmap::fromBm(szInMask), PaletteMask);
 			if(!In.mergeWithMask(InMask)) {
 				nLog::error("Mask incompatible with bitmap");

--- a/tools/src/common/fs.cpp
+++ b/tools/src/common/fs.cpp
@@ -45,7 +45,7 @@ std::string getExt(const std::string &szPath)
 	return szPath.substr(DotPos + 1);
 }
 
-std::string trimExt(const std::string &szPath)
+std::string removeExt(const std::string &szPath)
 {
 	auto DotPos = szPath.find_last_of('.');
 	if(DotPos == std::string::npos) {

--- a/tools/src/common/fs.h
+++ b/tools/src/common/fs.h
@@ -17,7 +17,7 @@ bool isDir(const std::string &szPath);
 
 std::string getExt(const std::string &szPath);
 
-std::string trimExt(const std::string &szPath);
+std::string removeExt(const std::string &szPath);
 
 std::string getBaseName(const std::string &szPath);
 

--- a/tools/src/common/palette.cpp
+++ b/tools/src/common/palette.cpp
@@ -196,7 +196,7 @@ bool tPalette::toGpl(const std::string &szPath)
 
 	// Header
 	Dest << "GIMP Palette\n";
-	Dest << fmt::format("Name: {}\n", trimExt(getBaseName(szPath)));
+	Dest << fmt::format("Name: {}\n", removeExt(getBaseName(szPath)));
 	Dest << "Columns: 4\n";
 	Dest << "#\n";
 

--- a/tools/src/palette_conv.cpp
+++ b/tools/src/palette_conv.cpp
@@ -33,7 +33,7 @@ int main(int lArgCount, const char *pArgs[])
 	std::string szPathIn = pArgs[1];
 
 	// Optional args' default values
-	std::string szPathOut = nFs::trimExt(szPathIn) + ".gpl";
+	std::string szPathOut = nFs::removeExt(szPathIn) + ".gpl";
 
 	// Search for optional args
 	if(lArgCount - 1 > 1) {


### PR DESCRIPTION
<!--- Use this only if you've made non-breaking improvements or bugfixes -->

## Description

Adds global hires (640x256) support for simplebuffer and scrollbuffer. Also ports some misc changes from os-cia branch since it's getting too big.

Introduces `TAG_VIEW_GLOBAL_HRES` flag, set to 1 by default, which futureproofs for per-viewport horizontal resolution flag. To actually enable hires, one must specify the `TAG_VPORT_HIRES` flag during vport creation.

This PR also makes the `TAG_VIEW_GLOBAL_PALETTE` set to 1 by default, reducing the boilerplate slightly. Updating the docs refers to updating for this particular change. The hires chapter is still yet to be written.

## Checklist
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [x] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.
