### PR TITLE
Add support for narrow view sizes and x offsets

### DIFF
--- a/include/ace/generic/screen.h
+++ b/include/ace/generic/screen.h
@@ -11,6 +11,8 @@ extern "C" {
 
 #include <ace/types.h>
 
+#define SCREEN_XOFFSET 0x81
+
 #define SCREEN_PAL_YOFFSET 0x2C
 #define SCREEN_PAL_WIDTH 320
 #define SCREEN_PAL_HEIGHT 256
@@ -38,9 +40,9 @@ extern "C" {
 // KaiN has needed. Add a calculation on proper wait pos (less BPP - later).
 
 // Vairn: AGA modes seem to need a smaller value than EHB, but the value which used to work.
-//  The original value of 0xe2-(7*4), worked for the AGA modes, which equates out to 0xC6, so I'll set it to that for 7bpp and 8bpp. 
+//  The original value of 0xe2-(7*4), worked for the AGA modes, which equates out to 0xC6, so I'll set it to that for 7bpp and 8bpp.
 // TODO: Test and find the most optional values.
-// TODO: Figure out if this is more related to fetchmodes for AGA. 
+// TODO: Figure out if this is more related to fetchmodes for AGA.
 static const UWORD s_pCopperWaitXByBitplanes[9] = {0x00, 0xDC, 0xDC, 0xDC, 0xDC, 0xDC, 0xDC, 0xC6, 0xC6};
 
 #ifdef __cplusplus

--- a/include/ace/managers/bob.h
+++ b/include/ace/managers/bob.h
@@ -84,6 +84,8 @@ typedef struct tBob {
  * @param pFront Double buffering's front buffer bitmap.
  * @param pBack Double buffering's back buffer bitmap.
  * @param uwAvailHeight True available height for Y-scroll in passed bitmap.
+ * For tileBuffer you should use `pTileBuffer->pScroll->uwBmAvailHeight`.
+ * For scrollBuffer you should use `pScrollBuffer->uwBmAvailHeight`.
  *
  * @see bobInit()
  * @see bobReallocateBgBuffers()

--- a/include/ace/utils/extview.h
+++ b/include/ace/utils/extview.h
@@ -28,11 +28,11 @@ typedef enum tTagView {
 	// If set to non-zero, view will use first vport's palette as global & ignore other ones.
 	TAG_VIEW_GLOBAL_PALETTE    = TAG_USER | 3,
 	// The X value for display window start.
-	// TAG_VIEW_WINDOW_START_X    = TAG_USER | 4,
+	TAG_VIEW_WINDOW_START_X    = TAG_USER | 4,
 	// The Y value for display window start.
 	TAG_VIEW_WINDOW_START_Y    = TAG_USER | 5,
 	// The width of display window.
-	// TAG_VIEW_WINDOW_WIDTH      = TAG_USER | 6,
+	TAG_VIEW_WINDOW_WIDTH      = TAG_USER | 6,
 	// The height of display window. Defaults to (lastPalScanline - TAG_VIEW_WINDOW_START_Y)
 	TAG_VIEW_WINDOW_HEIGHT     = TAG_USER | 7,
 	// If set to non-zero, view will use first vport's bpp value for whole screen.
@@ -121,7 +121,9 @@ typedef void (*tVpManagerFn)(tVpManager *pManager);
 typedef struct tView {
 	UBYTE ubVpCount;             ///< Viewport count.
 	UWORD uwFlags;               ///< Creation flags.
+	UBYTE ubPosX;                ///< Directly populates the DIWSTRT value.
 	UBYTE ubPosY;                ///< Directly populates the DIWSTRT value.
+	UWORD uwWidth;
 	UWORD uwHeight;
 	UWORD uwBplCon0;             ///< Initial/global bplcon0 values.
 	struct _tCopList *pCopList;  ///< Pointer to copperlist.

--- a/src/ace/managers/copper.c
+++ b/src/ace/managers/copper.c
@@ -485,6 +485,9 @@ UBYTE copUpdateFromBlocks(void) {
 		if(pBlock->ubUpdated) {
 			--pBlock->ubUpdated;
 		}
+		if(pBlock->uwCurrCount == 0) {
+			continue;
+		}
 
 		// Update WAIT
 		if(pBlock->uWaitPos.uwY > 0xFF) {

--- a/src/ace/managers/copper.c
+++ b/src/ace/managers/copper.c
@@ -490,18 +490,20 @@ UBYTE copUpdateFromBlocks(void) {
 		}
 
 		// Update WAIT
-		if(pBlock->uWaitPos.uwY > 0xFF) {
+		if(pBlock->uWaitPos.uwY >= 0xFF) {
 			// FIXME: double WAIT only when previous line ended before some pos
 			if(!ubWasLimitY) {
 				copSetWait((tCopWaitCmd*)&pBackBfr->pList[uwListPos], 0xDF, 0xFF);
 				++uwListPos;
 				ubWasLimitY = 1;
 			}
-			copSetWait(
-				(tCopWaitCmd*)&pBackBfr->pList[uwListPos],
-				pBlock->uWaitPos.uwX, pBlock->uWaitPos.uwY & 0xFF
-			);
-			++uwListPos;
+			if(pBlock->uWaitPos.uwY > 0xFF) {
+				copSetWait(
+					(tCopWaitCmd*)&pBackBfr->pList[uwListPos],
+					pBlock->uWaitPos.uwX, pBlock->uWaitPos.uwY & 0xFF
+				);
+				++uwListPos;
+			}
 		}
 		else {
 			copSetWait(

--- a/src/ace/managers/sprite.c
+++ b/src/ace/managers/sprite.c
@@ -234,7 +234,7 @@ void spriteProcess(tSprite *pSprite) {
 	// occupies 1 line of the bitmap.
 	UWORD uwVStart = s_pView->ubPosY + pSprite->wY;
 	UWORD uwVStop = uwVStart + pSprite->uwHeight;
-	UWORD uwHStart = s_pView->ubPosX + pSprite->wX;
+	UWORD uwHStart = s_pView->ubPosX - 1 + pSprite->wX; // For diwstrt 0x81, x offset equal to 128 worked fine, hence -1
 
 	tHardwareSpriteHeader *pHeader = (tHardwareSpriteHeader*)(pSprite->pBitmap->Planes[0]);
 	pHeader->uwRawPos = ((uwVStart << 8) | ((uwHStart) >> 1));

--- a/src/ace/managers/sprite.c
+++ b/src/ace/managers/sprite.c
@@ -232,10 +232,9 @@ void spriteProcess(tSprite *pSprite) {
 	#endif
 	// Sprite in list mode has 2-word header before and after data, each
 	// occupies 1 line of the bitmap.
-	// TODO: get rid of hardcoded 128 X offset in reasonable way.
 	UWORD uwVStart = s_pView->ubPosY + pSprite->wY;
 	UWORD uwVStop = uwVStart + pSprite->uwHeight;
-	UWORD uwHStart = 128 + pSprite->wX;
+	UWORD uwHStart = s_pView->ubPosX + pSprite->wX;
 
 	tHardwareSpriteHeader *pHeader = (tHardwareSpriteHeader*)(pSprite->pBitmap->Planes[0]);
 	pHeader->uwRawPos = ((uwVStart << 8) | ((uwHStart) >> 1));

--- a/src/ace/managers/viewport/scrollbuffer.c
+++ b/src/ace/managers/viewport/scrollbuffer.c
@@ -392,8 +392,9 @@ void scrollBufferReset(
 	}
 	pManager->uwModulo = pManager->pBack->BytesPerRow - (uwVpWidth >> 3) - 2;
 
-	pManager->uwDDfStrt = 0x0030;
-	pManager->uwDDfStop = 0x00D0;
+	pManager->uwDDfStrt = (pManager->sCommon.pVPort->pView->ubPosX + 15) / 2 - 16;
+	pManager->uwDDfStop = pManager->uwDDfStrt + ((pManager->sCommon.pVPort->pView->uwWidth / 16) - 1) * 8;
+	pManager->uwDDfStrt -= 8; // for scroll reasons
 	if(pManager->sCommon.pVPort->eFlags & VP_FLAG_HIRES) {
 		// Start/stop one 4-step bitplane fetch pattern later: 3120
 		pManager->uwDDfStrt += 4;
@@ -402,6 +403,7 @@ void scrollBufferReset(
 		// One word more for fetch
 		pManager->uwModulo -= 2;
 	}
+	logWrite("DDFSTRT: %04X, DDFSTOP: %04X, Modulo: %u\n", pManager->uwDDfStrt, pManager->uwDDfStop, pManager->uwModulo);
 
 	// Constant stuff in copperlist
 	tCopList *pCopList = pManager->sCommon.pVPort->pView->pCopList;

--- a/src/ace/managers/viewport/simplebuffer.c
+++ b/src/ace/managers/viewport/simplebuffer.c
@@ -92,11 +92,11 @@ static void simpleBufferInitializeCopperList(
 			pManager->sCommon.pVPort->uwOffsY +
 			pManager->sCommon.pVPort->pView->ubPosY -1
 		));
-		copSetMove(&pCmdList[1].sMove, &g_pCustom->ddfstop, uwDDfStop);    // Data fetch
+		copSetMove(&pCmdList[1].sMove, &g_pCustom->ddfstop, uwDDfStop); // Data fetch
 		copSetMove(&pCmdList[2].sMove, &g_pCustom->ddfstrt, uwDDfStrt);
-		copSetMove(&pCmdList[3].sMove, &g_pCustom->bpl1mod, uwModulo);  // Bitplane modulo
+		copSetMove(&pCmdList[3].sMove, &g_pCustom->bpl1mod, uwModulo); // Bitplane modulo
 		copSetMove(&pCmdList[4].sMove, &g_pCustom->bpl2mod, uwModulo);
-		copSetMove(&pCmdList[5].sMove, &g_pCustom->bplcon1, 0);         // Shift: 0
+		copSetMove(&pCmdList[5].sMove, &g_pCustom->bplcon1, 0); // Shift: 0
 
 		// Copy to front buffer since it needs initialization there too
 		for(UWORD i = pManager->uwCopperOffset; i < pManager->uwCopperOffset + 6; ++i) {
@@ -113,11 +113,11 @@ static void simpleBufferInitializeCopperList(
 	else {
 		tCopBlock *pBlock = pManager->pCopBlock;
 		pBlock->uwCurrCount = 0; // Rewind to beginning
-		copMove(pCopList, pBlock, &g_pCustom->ddfstop, 0x00D0);     // Data fetch
+		copMove(pCopList, pBlock, &g_pCustom->ddfstop, uwDDfStop); // Data fetch
 		copMove(pCopList, pBlock, &g_pCustom->ddfstrt, uwDDfStrt);
-		copMove(pCopList, pBlock, &g_pCustom->bpl1mod, uwModulo);   // Bitplane modulo
+		copMove(pCopList, pBlock, &g_pCustom->bpl1mod, uwModulo); // Bitplane modulo
 		copMove(pCopList, pBlock, &g_pCustom->bpl2mod, uwModulo);
-		copMove(pCopList, pBlock, &g_pCustom->bplcon1, 0);          // Shift: 0
+		copMove(pCopList, pBlock, &g_pCustom->bplcon1, 0); // Shift: 0
 		for (UBYTE i = 0; i < pManager->sCommon.pVPort->ubBpp; ++i) {
 			ULONG ulPlaneAddr = (ULONG)pManager->pBack->Planes[i] + ulBplOffs;
 			copMove(pCopList, pBlock, &g_pBplFetch[i].uwHi, ulPlaneAddr >> 16);

--- a/src/ace/managers/viewport/simplebuffer.c
+++ b/src/ace/managers/viewport/simplebuffer.c
@@ -40,8 +40,8 @@ static void simpleBufferInitializeCopperList(
 	UWORD uwModulo = pManager->pFront->BytesPerRow - (pManager->sCommon.pVPort->uwWidth >> 3);
 
 	// http://amigadev.elowar.com/read/ADCD_2.1/Hardware_Manual_guide/node0085.html
-	UWORD uwDDfStrt = 0x0038;
-	UWORD uwDDfStop = 0x00D0;
+	UWORD uwDDfStrt = (pManager->sCommon.pVPort->pView->ubPosX + 15) / 2 - 16;
+	UWORD uwDDfStop = uwDDfStrt + ((pManager->sCommon.pVPort->pView->uwWidth / 16) - 1) * 8;
 	if(pManager->sCommon.pVPort->eFlags & VP_FLAG_HIRES) {
 		uwDDfStrt += 4;
 		uwDDfStop += 4;


### PR DESCRIPTION
<!--- Use this only if you've made non-breaking improvements or bugfixes -->

## Description

Adds support for setting view widths different than 320px as well as adding an X margin. Sample creation of 256x224 view:

```c
	s_pView = viewCreate(0,
		TAG_VIEW_WINDOW_HEIGHT, 224,
		TAG_VIEW_WINDOW_WIDTH, 256,
		TAG_VIEW_WINDOW_START_X, SCREEN_XOFFSET + (SCREEN_PAL_WIDTH - 256) / 2,
	TAG_END);
```

## Checklist
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
