### PR TITLE
Generalize tilebuffer's tile index type

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -51,11 +51,13 @@ set(ACE_DEBUG OFF CACHE BOOL "Build with ACE-specific debug/safety functionality
 set(ACE_DEBUG_UAE OFF CACHE BOOL "With ACE_DEBUG enabled, output log to UAE console.")
 set(ACE_BOB_WRAP_Y ON CACHE BOOL "Conrols Y-wrapping support in bob manager. Disable for extra performance in simple buffer scenarios.")
 set(ACE_USE_ECS_FEATURES OFF CACHE BOOL "Enable ECS feature sets.")
+set(ACE_TILEBUFFER_TILE_TYPE UBYTE CACHE STRING "Specify type used for storing tile indices in tileBuffer manager.")
 message(STATUS "[ACE] ACE_LIBRARY_KIND: '${ACE_LIBRARY_KIND}'")
 message(STATUS "[ACE] ACE_DEBUG: '${ACE_DEBUG}'")
 message(STATUS "[ACE] ACE_DEBUG_UAE: '${ACE_DEBUG_UAE}'")
 message(STATUS "[ACE] ACE_BOB_WRAP_Y: '${ACE_BOB_WRAP_Y}'")
 message(STATUS "[ACE] ACE_USE_ECS_FEATURES: '${ACE_USE_ECS_FEATURES}'")
+message(STATUS "[ACE] ACE_TILEBUFFER_TILE_TYPE: '${ACE_TILEBUFFER_TILE_TYPE}'")
 
 # Linux/other UNIX get a lower-case binary name
 set(TARGET_NAME ${PROJECT_NAME_LOWER})
@@ -81,6 +83,7 @@ endif()
 if(ACE_USE_ECS_FEATURES)
 	target_compile_definitions(${TARGET_NAME} PUBLIC ACE_USE_ECS_FEATURES)
 endif()
+target_compile_definitions(${TARGET_NAME} PUBLIC ACE_TILEBUFFER_TILE_TYPE=${ACE_TILEBUFFER_TILE_TYPE})
 
 if(M68K_COMPILER MATCHES "Bartman")
 	include(cmake/CPM.cmake)

--- a/include/ace/managers/viewport/tilebuffer.h
+++ b/include/ace/managers/viewport/tilebuffer.h
@@ -79,7 +79,13 @@ typedef enum tTileBufferCreateTags {
 	 *
 	 * @see tileBufferQueueProcess()
 	 */
-	TAG_TILEBUFFER_REDRAW_QUEUE_LENGTH = (TAG_USER | 11)
+	TAG_TILEBUFFER_REDRAW_QUEUE_LENGTH = (TAG_USER | 11),
+
+	/**
+	 * @brief Maximum tile index used in the tileset.
+	 * Optional, limits the tile lookup table size.
+	 */
+	TAG_TILEBUFFER_MAX_TILESET_SIZE = (TAG_USER | 12),
 } tTileBufferCreateTags;
 
 /* types */
@@ -130,8 +136,9 @@ typedef struct _tTileBufferManager {
 	UBYTE ubMarginYLength; ///< Ditto, up & down
 	UBYTE ubQueueSize;
 	// Redraw state and double buffering
-	tRedrawState pRedrawStates[2];
 	UBYTE ubStateIdx;
+	tRedrawState pRedrawStates[2];
+	ULONG ulMaxTilesetSize;
 } tTileBufferManager;
 
 /* globals */

--- a/include/ace/managers/viewport/tilebuffer.h
+++ b/include/ace/managers/viewport/tilebuffer.h
@@ -23,6 +23,8 @@ extern "C" {
 #include <ace/managers/viewport/camera.h>
 #include <ace/managers/viewport/scrollbuffer.h>
 
+typedef ACE_TILEBUFFER_TILE_TYPE tTileBufferTileIndex;
+
 typedef enum tTileBufferCreateTags {
 	/**
 	 * @brief Pointer to parent vPort. Mandatory.
@@ -120,7 +122,7 @@ typedef struct _tTileBufferManager {
 	UWORD uwMarginedHeight;       ///< Height of visible area + margins
 	                              ///  TODO: refresh when scrollbuffer changes
 	tTileDrawCallback cbTileDraw; ///< Called when tile is redrawn
-	ACE_TILEBUFFER_TILE_TYPE **pTileData; ///< 2D array of tile indices
+	tTileBufferTileIndex **pTileData; ///< 2D array of tile indices
 	tBitMap *pTileSet;            ///< Tileset - one tile beneath another
 	UBYTE **pTileSetOffsets;      ///< Lookup table for tile offsets in pTileSet
 	// Margin & queue geometry
@@ -244,7 +246,7 @@ UBYTE tileBufferIsRectFullyOnBuffer(
  * @param Index Index of tile to be placed on given position.
  */
 void tileBufferSetTile(
-	tTileBufferManager *pManager, UWORD uwX, UWORD uwY, ACE_TILEBUFFER_TILE_TYPE Index
+	tTileBufferManager *pManager, UWORD uwX, UWORD uwY, tTileBufferTileIndex Index
 );
 
 static inline UBYTE tileBufferGetRawCopperlistInstructionCountStart(UBYTE ubBpp) {

--- a/include/ace/managers/viewport/tilebuffer.h
+++ b/include/ace/managers/viewport/tilebuffer.h
@@ -9,8 +9,6 @@
 extern "C" {
 #endif
 
-#ifdef AMIGA
-
 /**
  * Tilemap buffer manager
  * Provides speed- and memory-efficient tilemap buffer
@@ -122,7 +120,7 @@ typedef struct _tTileBufferManager {
 	UWORD uwMarginedHeight;       ///< Height of visible area + margins
 	                              ///  TODO: refresh when scrollbuffer changes
 	tTileDrawCallback cbTileDraw; ///< Called when tile is redrawn
-	UBYTE **pTileData;            ///< 2D array of tile indices
+	ACE_TILEBUFFER_TILE_TYPE **pTileData; ///< 2D array of tile indices
 	tBitMap *pTileSet;            ///< Tileset - one tile beneath another
 	UBYTE **pTileSetOffsets;      ///< Lookup table for tile offsets in pTileSet
 	// Margin & queue geometry
@@ -243,10 +241,10 @@ UBYTE tileBufferIsRectFullyOnBuffer(
  * @param pManager The tile manager to be used.
  * @param uwX The X coordinate of tile, in tile-space.
  * @param uwY The Y coordinate of tile, in tile-space.
- * @param uwIdx Index of tile to be placed on given position.
+ * @param Index Index of tile to be placed on given position.
  */
 void tileBufferSetTile(
-	tTileBufferManager *pManager, UWORD uwX, UWORD uwY, UWORD uwIdx
+	tTileBufferManager *pManager, UWORD uwX, UWORD uwY, ACE_TILEBUFFER_TILE_TYPE Index
 );
 
 static inline UBYTE tileBufferGetRawCopperlistInstructionCountStart(UBYTE ubBpp) {
@@ -256,8 +254,6 @@ static inline UBYTE tileBufferGetRawCopperlistInstructionCountStart(UBYTE ubBpp)
 static inline UBYTE tileBufferGetRawCopperlistInstructionCountBreak(UBYTE ubBpp) {
     return scrollBufferGetRawCopperlistInstructionCountBreak(ubBpp);
 }
-
-#endif // AMIGA
 
 #ifdef __cplusplus
 }

--- a/src/ace/managers/viewport/tilebuffer.c
+++ b/src/ace/managers/viewport/tilebuffer.c
@@ -349,10 +349,10 @@ static UWORD tileBufferSetupTileDraw(const tTileBufferManager *pManager) {
  */
 FN_HOTSPOT
 static inline void tileBufferContinueTileDraw(
-	const tTileBufferManager *pManager, const ACE_TILEBUFFER_TILE_TYPE *pTileDataColumn,
+	const tTileBufferManager *pManager, const tTileBufferTileIndex *pTileDataColumn,
 	UWORD uwTileY, UWORD uwBltsize, ULONG ulDstOffs, PLANEPTR pDstPlane, UBYTE ubSetDst
 ) {
-	ACE_TILEBUFFER_TILE_TYPE TileToDraw = pTileDataColumn[uwTileY];
+	tTileBufferTileIndex TileToDraw = pTileDataColumn[uwTileY];
 
 	if (!(uwBltsize & BLIT_WORDS_NON_INTERLEAVED_BIT)) {
 		UBYTE *pUbBltapt = pManager->pTileSetOffsets[TileToDraw];
@@ -421,7 +421,7 @@ void tileBufferProcess(tTileBufferManager *pManager) {
 				UWORD uwTileEnd = pState->pMarginX->wTileEnd;
 				UWORD uwMarginedHeight = pManager->uwMarginedHeight;
 				UWORD uwTilePos = pState->pMarginX->wTilePos;
-				const ACE_TILEBUFFER_TILE_TYPE *pTileColumn = pManager->pTileData[uwTilePos];
+				const tTileBufferTileIndex *pTileColumn = pManager->pTileData[uwTilePos];
 				UWORD uwDstBytesPerRow = pManager->pScroll->pBack->BytesPerRow;
 				PLANEPTR pDstPlane = pManager->pScroll->pBack->Planes[0];
 				ULONG ulDstOffs = uwDstBytesPerRow * uwTileOffsY + (uwTileOffsX >> 3);
@@ -524,7 +524,7 @@ void tileBufferProcess(tTileBufferManager *pManager) {
 				UWORD uwTileCurr = pState->pMarginY->wTileCurr;
 				UWORD uwTileEnd = pState->pMarginY->wTileEnd;
 				UWORD uwTilePos = pState->pMarginY->wTilePos;
-				ACE_TILEBUFFER_TILE_TYPE **pTileData = pManager->pTileData;
+				tTileBufferTileIndex **pTileData = pManager->pTileData;
 				PLANEPTR pDstPlane = pManager->pScroll->pBack->Planes[0];
 				ULONG ulDstOffs = pManager->pScroll->pBack->BytesPerRow * uwTileOffsY + (uwTileOffsX >> 3);
 				UWORD uwDstOffsStep = ubTileSize >> 3;
@@ -610,7 +610,7 @@ void tileBufferRedrawAll(tTileBufferManager *pManager) {
 	UWORD uwTileOffsY = (wStartY << ubTileShift) & (pManager->uwMarginedHeight - 1);
 	UWORD uwDstBytesPerRow = pManager->pScroll->pBack->BytesPerRow;
 	PLANEPTR pDstPlane = pManager->pScroll->pBack->Planes[0];
-	ACE_TILEBUFFER_TILE_TYPE **pTileData = pManager->pTileData;
+	tTileBufferTileIndex **pTileData = pManager->pTileData;
 	UWORD uwBltsize = tileBufferSetupTileDraw(pManager);
 	UWORD uwTileOffsX = (wStartX << ubTileShift);
 	UWORD uwDstOffsStep = ubTileSize >> 3;
@@ -682,7 +682,7 @@ void tileBufferDrawTileQuick(
 	const tTileBufferManager *pManager, UWORD uwTileX, UWORD uwTileY,
 	UWORD uwBfrX, UWORD uwBfrY
 ) {
-	ACE_TILEBUFFER_TILE_TYPE TileToDraw = pManager->pTileData[uwTileX][uwTileY];
+	tTileBufferTileIndex TileToDraw = pManager->pTileData[uwTileX][uwTileY];
 	UBYTE ubTileShift = pManager->ubTileShift;
 	// This can't use safe blit fn because when scrolling in X direction,
 	// we need to draw on bitplane 1 as if it is part of bitplane 0.
@@ -784,7 +784,7 @@ UBYTE tileBufferIsRectFullyOnBuffer(
 }
 
 void tileBufferSetTile(
-	tTileBufferManager *pManager, UWORD uwX, UWORD uwY, ACE_TILEBUFFER_TILE_TYPE Index
+	tTileBufferManager *pManager, UWORD uwX, UWORD uwY, tTileBufferTileIndex Index
 ) {
  	pManager->pTileData[uwX][uwY] = Index;
 	tileBufferInvalidateTile(pManager, uwX, uwY);

--- a/src/ace/managers/viewport/tilebuffer.c
+++ b/src/ace/managers/viewport/tilebuffer.c
@@ -9,7 +9,7 @@
 #include <ace/utils/tag.h>
 #include <proto/exec.h> // Bartman's compiler needs this
 
-#define TILEBUFFER_MAX_TILE_COUNT (1 << (8 * sizeof(tTileBufferTileIndex)))
+#define TILEBUFFER_MAX_TILESET_SIZE (1 << (8 * sizeof(tTileBufferTileIndex)))
 
 static UBYTE shiftFromPowerOfTwo(UWORD uwPot) {
 	UBYTE ubPower = 0;
@@ -129,6 +129,9 @@ tTileBufferManager *tileBufferCreate(void *pTags, ...) {
 	isDblBuf = tagGet(pTags, vaTags, TAG_TILEBUFFER_IS_DBLBUF, 0);
 	uwCoplistOffStart = tagGet(pTags, vaTags, TAG_TILEBUFFER_COPLIST_OFFSET_START, -1);
 	uwCoplistOffBreak = tagGet(pTags, vaTags, TAG_TILEBUFFER_COPLIST_OFFSET_BREAK, -1);
+	pManager->ulMaxTilesetSize = tagGet(
+		pTags, vaTags, TAG_TILEBUFFER_MAX_TILESET_SIZE, TILEBUFFER_MAX_TILESET_SIZE
+	);
 	tileBufferReset(pManager, uwTileX, uwTileY, ubBitmapFlags, isDblBuf, uwCoplistOffStart, uwCoplistOffBreak);
 
 	pManager->ubQueueSize = tagGet(
@@ -189,7 +192,7 @@ void tileBufferDestroy(tTileBufferManager *pManager) {
 
 	// Free tile offset lookup table
 	if(pManager->pTileSetOffsets) {
-		memFree(pManager->pTileSetOffsets, sizeof(pManager->pTileSetOffsets[0]) * TILEBUFFER_MAX_TILE_COUNT);
+		memFree(pManager->pTileSetOffsets, sizeof(pManager->pTileSetOffsets[0]) * pManager->ulMaxTilesetSize);
 	}
 
 	if(pManager->pRedrawStates[0].pPendingQueue) {
@@ -225,7 +228,7 @@ void tileBufferReset(
 
 	// Free old tile offset lookup table
 	if(pManager->pTileSetOffsets) {
-		memFree(pManager->pTileSetOffsets, sizeof(pManager->pTileSetOffsets[0]) * TILEBUFFER_MAX_TILE_COUNT);
+		memFree(pManager->pTileSetOffsets, sizeof(pManager->pTileSetOffsets[0]) * pManager->ulMaxTilesetSize);
 	}
 
 	// Init new tile data
@@ -239,8 +242,8 @@ void tileBufferReset(
 	}
 
 	// Init tile offset lookup table
-	pManager->pTileSetOffsets = memAllocFastClear(sizeof(pManager->pTileSetOffsets[0]) * TILEBUFFER_MAX_TILE_COUNT);
-	for (ULONG i = 0; i < TILEBUFFER_MAX_TILE_COUNT; ++i) {
+	pManager->pTileSetOffsets = memAllocFast(sizeof(pManager->pTileSetOffsets[0]) * pManager->ulMaxTilesetSize);
+	for (ULONG i = 0; i < pManager->ulMaxTilesetSize; ++i) {
 		pManager->pTileSetOffsets[i] = pManager->pTileSet->Planes[0] + (pManager->pTileSet->BytesPerRow * (i << pManager->ubTileShift));
 	}
 

--- a/src/ace/managers/viewport/tilebuffer.c
+++ b/src/ace/managers/viewport/tilebuffer.c
@@ -9,6 +9,8 @@
 #include <ace/utils/tag.h>
 #include <proto/exec.h> // Bartman's compiler needs this
 
+#define TILEBUFFER_MAX_TILE_COUNT (1 << (8 * sizeof(tTileBufferTileIndex)))
+
 static UBYTE shiftFromPowerOfTwo(UWORD uwPot) {
 	UBYTE ubPower = 0;
 	while(uwPot > 1) {
@@ -187,7 +189,7 @@ void tileBufferDestroy(tTileBufferManager *pManager) {
 
 	// Free tile offset lookup table
 	if(pManager->pTileSetOffsets) {
-		memFree(pManager->pTileSetOffsets, sizeof(pManager->pTileSetOffsets[0]) * 256);
+		memFree(pManager->pTileSetOffsets, sizeof(pManager->pTileSetOffsets[0]) * TILEBUFFER_MAX_TILE_COUNT);
 	}
 
 	if(pManager->pRedrawStates[0].pPendingQueue) {
@@ -223,7 +225,7 @@ void tileBufferReset(
 
 	// Free old tile offset lookup table
 	if(pManager->pTileSetOffsets) {
-		memFree(pManager->pTileSetOffsets, sizeof(pManager->pTileSetOffsets[0]) * 256);
+		memFree(pManager->pTileSetOffsets, sizeof(pManager->pTileSetOffsets[0]) * TILEBUFFER_MAX_TILE_COUNT);
 	}
 
 	// Init new tile data
@@ -237,8 +239,8 @@ void tileBufferReset(
 	}
 
 	// Init tile offset lookup table
-	pManager->pTileSetOffsets = memAllocFastClear(sizeof(pManager->pTileSetOffsets[0]) * 256);
-	for (UWORD i = 0; i < 256; ++i) {
+	pManager->pTileSetOffsets = memAllocFastClear(sizeof(pManager->pTileSetOffsets[0]) * TILEBUFFER_MAX_TILE_COUNT);
+	for (ULONG i = 0; i < TILEBUFFER_MAX_TILE_COUNT; ++i) {
 		pManager->pTileSetOffsets[i] = pManager->pTileSet->Planes[0] + (pManager->pTileSet->BytesPerRow * (i << pManager->ubTileShift));
 	}
 

--- a/src/ace/utils/extview.c
+++ b/src/ace/utils/extview.c
@@ -208,10 +208,12 @@ void viewLoad(tView *pView) {
 		pView->uwBplCon0 |= BV(9); // composite output
 
 		g_sCopManager.pCopList = pView->pCopList;
-		g_pCustom->bplcon0 = pView->uwBplCon0; // BPP + composite output
-		g_pCustom->fmode = 0; // AGA fix
-		g_pCustom->bplcon3 = 0; // AGA fix
-		g_pCustom->diwstrt = (pView->ubPosY << 8) | 0x81; // HSTART: 0x81
+		g_pCustom->bplcon0 =pView->uwBplCon0; // BPP + composite output
+		g_pCustom->fmode = 0;        // AGA fix
+		g_pCustom->bplcon3 = 0;      // AGA fix
+
+		UWORD uwDiwStartX = 0x81;
+		UWORD uwDiwStopX = uwDiwStartX + SCREEN_PAL_WIDTH - 256;
 		UWORD uwDiwStopY = pView->ubPosY + pView->uwHeight;
 		if(BTST(uwDiwStopY, 8) == BTST(uwDiwStopY, 7)) {
 			logWrite(
@@ -219,7 +221,8 @@ void viewLoad(tView *pView) {
 				uwDiwStopY, BTST(uwDiwStopY, 8), BTST(uwDiwStopY, 7)
 			);
 		}
-		g_pCustom->diwstop = ((uwDiwStopY & 0xFF) << 8) | 0xC1; // HSTOP: 0xC1
+		g_pCustom->diwstrt = (pView->ubPosY << 8) | uwDiwStartX; // HSTART: 0x81
+		g_pCustom->diwstop = ((uwDiwStopY & 0xFF) << 8) | uwDiwStopX; // HSTOP: 0xC1
 		viewUpdateGlobalPalette(pView);
 	}
 	copProcessBlocks();

--- a/tools/CMakeLists.txt
+++ b/tools/CMakeLists.txt
@@ -27,7 +27,7 @@ CPMAddPackage(
 file(GLOB COMMON_src src/common/*.cpp src/common/*.c)
 file(GLOB_RECURSE COMMON_hdr src/common/*.h src/common/*.hpp)
 add_library(common STATIC ${COMMON_src} ${COMMON_hdr})
-if(NOT MSVC AND NOT APPLE)
+if(MINGW)
 	message(STATUS "Building STATIC executables")
 	target_link_libraries(common PUBLIC -static)
 endif()


### PR DESCRIPTION
<!--- Use this only if you've made non-breaking improvements or bugfixes -->

## Description

Allows having a tilemap larger than 256 tiles. Can be configured in CMakeLists.txt by setting following before adding ACE's subdirectory:

```cmake
set(ACE_TILEBUFFER_TILE_TYPE UWORD) # Or any other type
```

Defaults to `UBYTE`.

## Checklist
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
