### PR TITLE
Change sprite manager to allow user to pass their own blank sprite.

### DIFF
--- a/docs/programming/sprites.md
+++ b/docs/programming/sprites.md
@@ -49,8 +49,8 @@ The manager works in block, as well as raw copperlist mode.
 void myGsCreate(void) {
   // Some stuff goes here...
 
-  spriteManagerCreate(s_pView, 0); // For raw copper mode, pass position on
-                                   // copperlist for sprite initialization.
+  spriteManagerCreate(s_pView, 0, NULL); // For raw copper mode, pass position on
+                                         // copperlist for sprite initialization.
   systemSetDmaBit(DMAB_SPRITE, 1); // Enable sprite DMA.
 
   // Stuff continues...

--- a/include/ace/managers/sprite.h
+++ b/include/ace/managers/sprite.h
@@ -48,13 +48,15 @@ typedef struct tSprite {
  * @param pView View used for displaying sprites.
  * @param uwRawCopPos In raw mode, specifies an offset on where
  * the sprite commands should reside. Requires space of 16 copper commands.
+ * @param pBlankSprite 2 words of CHIP memory (the blank sprite control words).
+ * Pass NULL to let the manager deal with the blank sprite memory.
  *
  * @see spriteDisableInCopBlockMode()
  * @see spriteDisableInCopRawMode()
  * @see systemSetDmaBit()
  * @see spriteManagerDestroy()
  */
-void spriteManagerCreate(const tView *pView, UWORD uwRawCopPos);
+void spriteManagerCreate(const tView *pView, UWORD uwRawCopPos, ULONG pBlankSprite[1]);
 
 /**
  * @brief Destroys the hardware sprite manager.

--- a/include/ace/utils/sprite.h
+++ b/include/ace/utils/sprite.h
@@ -26,10 +26,11 @@ extern "C" {
  * @param pList Copperlist to be edited.
  * @param eSpriteMask Determines sprites to be disabled.
  * @param uwCmdOffs Start position on raw copperlist.
+ * @param pBlankSprite 2 words of CHIP memory (the blank sprite control words)
  * @return Number of MOVE instructions added.
  */
 UBYTE spriteDisableInCopRawMode(
-	tCopList *pList, tSpriteMask eSpriteMask, UWORD uwCmdOffs
+	tCopList *pList, tSpriteMask eSpriteMask, UWORD uwCmdOffs, ULONG pBlankSprite[1]
 );
 
 /**
@@ -38,9 +39,10 @@ UBYTE spriteDisableInCopRawMode(
  *
  *  @param pList Copperlist to be edited.
  *  @param eSpriteMask Determines sprites to be disabled.
+ *  @param pBlankSprite 2 words of CHIP memory (the blank sprite control words)
  *
  *  @return Pointer to newly created copBlock.
  */
-tCopBlock *spriteDisableInCopBlockMode(tCopList *pList, tSpriteMask eSpriteMask);
+tCopBlock *spriteDisableInCopBlockMode(tCopList *pList, tSpriteMask eSpriteMask, ULONG pBlankSprite[1]);
 
 #endif // _ACE_UTILS_SPRITE_H_

--- a/src/ace/managers/sprite.c
+++ b/src/ace/managers/sprite.c
@@ -44,7 +44,7 @@ void spriteManagerCreate(const tView *pView, UWORD uwRawCopPos, ULONG pBlankSpri
 		s_isOwningBlankSprite = 1;
 		s_pBlankSprite = memAllocChipClear(sizeof(ULONG));
 		// Just to make sure we don't accidentally mismatch the control words size
-		_Static_assert(sizeof(ULONG) == sizeof(tHardwareSpriteHeader));
+		_Static_assert(sizeof(ULONG) == sizeof(tHardwareSpriteHeader), "We expect a Hardware sprite to have a ULONG sized header");
 	}
 	// TODO: add support for non-chained mode (setting sprxdat with copper)?
 	s_pView = pView;

--- a/src/ace/managers/sprite.c
+++ b/src/ace/managers/sprite.c
@@ -34,7 +34,7 @@ static void spriteChannelRequestCopperUpdate(tSpriteChannel *pChannel) {
 void spriteManagerCreate(const tView *pView, UWORD uwRawCopPos, ULONG pBlankSprite[1]) {
 	if (pBlankSprite) {
 #ifdef ACE_DEBUG
-		if ((ULONG)pBlankSprite > memGetChipSize() - sizeof(ULONG)) {
+		if (!(memType(pBlankSprite) & MEMF_CHIP)) {
 			logWrite("ERR: ILLEGAL NON-CHIP memory location for blank sprite!");
 		}
 #endif

--- a/src/ace/managers/sprite.c
+++ b/src/ace/managers/sprite.c
@@ -23,14 +23,29 @@ typedef struct tSpriteChannel {
 
 static const tView *s_pView;
 static tSpriteChannel s_pChannelsData[HARDWARE_SPRITE_CHANNEL_COUNT];
-static const tHardwareSpriteHeader CHIP s_uBlankSprite;
+static ULONG *s_pBlankSprite;
+static UBYTE s_isOwningBlankSprite;
 static tCopBlock *s_pInitialClearCopBlock;
 
 static void spriteChannelRequestCopperUpdate(tSpriteChannel *pChannel) {
 	pChannel->ubCopperRegenCount = 2; // for front/back buffers in raw mode
 }
 
-void spriteManagerCreate(const tView *pView, UWORD uwRawCopPos) {
+void spriteManagerCreate(const tView *pView, UWORD uwRawCopPos, ULONG pBlankSprite[1]) {
+	if (pBlankSprite) {
+#ifdef ACE_DEBUG
+		if ((ULONG)pBlankSprite > memGetChipSize() - sizeof(ULONG)) {
+			logWrite("ERR: ILLEGAL NON-CHIP memory location for blank sprite!");
+		}
+#endif
+		s_isOwningBlankSprite = 0;
+		s_pBlankSprite = pBlankSprite;
+	} else {
+		s_isOwningBlankSprite = 1;
+		s_pBlankSprite = memAllocChipClear(sizeof(ULONG));
+		// Just to make sure we don't accidentally mismatch the control words size
+		_Static_assert(sizeof(ULONG) == sizeof(tHardwareSpriteHeader));
+	}
 	// TODO: add support for non-chained mode (setting sprxdat with copper)?
 	s_pView = pView;
 	for(UBYTE i = HARDWARE_SPRITE_CHANNEL_COUNT; i--;) {
@@ -45,7 +60,8 @@ void spriteManagerCreate(const tView *pView, UWORD uwRawCopPos) {
 		s_pInitialClearCopBlock = spriteDisableInCopBlockMode(
 			s_pView->pCopList,
 			SPRITE_0 | SPRITE_1 | SPRITE_2 | SPRITE_3 |
-			SPRITE_4 | SPRITE_5 | SPRITE_6 | SPRITE_7
+			SPRITE_4 | SPRITE_5 | SPRITE_6 | SPRITE_7,
+			s_pBlankSprite
 		);
 	}
 	else {
@@ -53,7 +69,8 @@ void spriteManagerCreate(const tView *pView, UWORD uwRawCopPos) {
 		spriteDisableInCopRawMode(
 			s_pView->pCopList,
 			SPRITE_0 | SPRITE_1 | SPRITE_2 | SPRITE_3 |
-			SPRITE_4 | SPRITE_5 | SPRITE_6 | SPRITE_7, uwRawCopPos
+			SPRITE_4 | SPRITE_5 | SPRITE_6 | SPRITE_7, uwRawCopPos,
+			s_pBlankSprite
 		);
 	}
 }
@@ -68,6 +85,9 @@ void spriteManagerDestroy(void) {
 	}
 	if(s_pInitialClearCopBlock) {
 		copBlockDestroy(s_pView->pCopList, s_pInitialClearCopBlock);
+	}
+	if (s_isOwningBlankSprite) {
+		memFree(s_pBlankSprite, sizeof(ULONG));
 	}
 	systemUnuse();
 }
@@ -191,7 +211,7 @@ void spriteProcessChannel(UBYTE ubChannelIndex) {
 		pCopBlock->uwCurrCount = 0;
 		ULONG ulSprAddr = (
 			pSprite->isEnabled ?
-			(ULONG)(pSprite->pBitmap->Planes[0]) : s_uBlankSprite.ulRaw
+			(ULONG)(pSprite->pBitmap->Planes[0]) : (ULONG)s_pBlankSprite
 		);
 		copMove(
 			s_pView->pCopList, pCopBlock,
@@ -209,7 +229,7 @@ void spriteProcessChannel(UBYTE ubChannelIndex) {
 
 		ULONG ulSprAddr = (
 			pSprite && pSprite->isEnabled ?
-			(ULONG)(pSprite->pBitmap->Planes[0]) : s_uBlankSprite.ulRaw
+			(ULONG)(pSprite->pBitmap->Planes[0]) : (ULONG)s_pBlankSprite
 		);
 		copSetMoveVal(&pList[0].sMove, ulSprAddr >> 16);
 		copSetMoveVal(&pList[1].sMove, ulSprAddr & 0xFFFF);

--- a/src/ace/utils/sprite.c
+++ b/src/ace/utils/sprite.c
@@ -5,9 +5,7 @@
 #include <ace/utils/sprite.h>
 #include <ace/utils/custom.h>
 
-static const tHardwareSpriteHeader CHIP s_uBlankSprite;
-
-tCopBlock *spriteDisableInCopBlockMode(tCopList *pList, tSpriteMask eSpriteMask) {
+tCopBlock *spriteDisableInCopBlockMode(tCopList *pList, tSpriteMask eSpriteMask, ULONG pBlankSprite[1]) {
 	// TODO: move to sprite manager?
 	UBYTE ubCmdCount = 0;
 	tSpriteMask eMask = eSpriteMask;
@@ -21,7 +19,7 @@ tCopBlock *spriteDisableInCopBlockMode(tCopList *pList, tSpriteMask eSpriteMask)
 	}
 
 	// Set instructions
-	ULONG ulBlank = s_uBlankSprite.ulRaw;
+	ULONG ulBlank = (ULONG)pBlankSprite;
 	tCopBlock *pBlock = copBlockCreate(pList, ubCmdCount, 0, 0);
 	eMask = eSpriteMask;
 	for(UBYTE i = 0; i < HARDWARE_SPRITE_CHANNEL_COUNT; ++i) {
@@ -35,11 +33,11 @@ tCopBlock *spriteDisableInCopBlockMode(tCopList *pList, tSpriteMask eSpriteMask)
 }
 
 UBYTE spriteDisableInCopRawMode(
-	tCopList *pList, tSpriteMask eSpriteMask, UWORD uwCmdOffs
+	tCopList *pList, tSpriteMask eSpriteMask, UWORD uwCmdOffs, ULONG pBlankSprite[1]
 ) {
 	// TODO: move to sprite
 	UBYTE ubCmdCount = 0;
-	ULONG ulBlank = s_uBlankSprite.ulRaw;
+	ULONG ulBlank = (ULONG)pBlankSprite;
 
 	// No WAIT - could be done earlier by other stuff
 	tCopMoveCmd *pCmd = &pList->pBackBfr->pList[uwCmdOffs].sMove;


### PR DESCRIPTION
This is not nice, but I wanted to start discussing how to get around the problem that I get into conflicts with the sprite manager if I do my own sprite system:

```
[build] D:/greatflight/src/sprites.c:126:19: error: 's_spriteData' causes a section type conflict with 's_uBlankSprite'
[build]   126 | static UWORD CHIP s_spriteData[] = {
[build]       |                   ^
[build] D:/greatflight/deps/ACE/src/ace/managers/sprite.c:29:41: note: 's_uBlankSprite' was declared here
[build]    29 | static const tHardwareSpriteHeader CHIP s_uBlankSprite;
[build]       |                                         ^
[build] lto-wrapper.exe: fatal error: c:\Users\timfe\.vscode\extensions\bartmanabyss.amiga-debug-1.7.7\bin\win32\opt\bin\m68k-amiga-elf-gcc.exe returned 1 exit status
```

This hack works around it for me and for now, but it's confusing since it doesn't actually prevent you from using the sprite system and then you get error messages that are again hard to understand. So just putting this here to discuss.