### PR TITLE
Fix wait position for setting sprite pointers in cop block mode

### DIFF
--- a/src/ace/managers/sprite.c
+++ b/src/ace/managers/sprite.c
@@ -97,7 +97,7 @@ tSprite *spriteAdd(UBYTE ubChannelIndex, tBitMap *pBitmap) {
 				return 0;
 			}
 #endif
-			pChannel->pCopBlock = copBlockCreate(s_pView->pCopList, 2, 0, 0);
+			pChannel->pCopBlock = copBlockCreate(s_pView->pCopList, 2, 0, 1);
 		}
 	}
 


### PR DESCRIPTION
There's a cop block waiting for 0,0 to reset all sprite pointers to 0x0, so to ensure proper sorting, the cop blocks to set sprite pointers for enabled sprites should wait for a line later.
