### PR TITLE
Add support for compression

### DIFF
--- a/cmake/ace_functions.cmake
+++ b/cmake/ace_functions.cmake
@@ -329,7 +329,7 @@ function(packDirectory)
 	cmake_parse_arguments(
 		args
 		"COMPRESS"
-		"SOURCE_DIR;DEST_FILE;TARGET"
+		"SOURCE_DIR;DEST_FILE;TARGET;REORDER_FILE"
 		""
 		${ARGN}
 	)
@@ -340,6 +340,9 @@ function(packDirectory)
 
 	if(${args_COMPRESS})
 		set(argsOptional ${argsOptional} -c)
+	endif()
+	if(NOT "${args_REORDER_FILE} " STREQUAL " ")
+		set(argsOptional ${argsOptional} -r ${args_REORDER_FILE})
 	endif()
 
 	add_custom_command(

--- a/cmake/ace_functions.cmake
+++ b/cmake/ace_functions.cmake
@@ -239,7 +239,7 @@ function(convertAudio)
 	getToolPath(audio_conv TOOL_AUDIO_CONV)
 	cmake_parse_arguments(
 		args
-		"STRICT;PTPLAYER;NORMALIZE;"
+		"STRICT;PTPLAYER;NORMALIZE;COMPRESS;"
 		"TARGET;SOURCE;DESTINATION;PAD_BYTES;DIVIDE_AMPLITUDE;CHECK_DIVIDED_AMPLITUDE"
 		"" ${ARGN}
 	)
@@ -252,6 +252,9 @@ function(convertAudio)
 	endif()
 	if(${args_NORMALIZE})
 		set(argsOptional ${argsOptional} -n)
+	endif()
+	if(${args_COMPRESS})
+		set(argsOptional ${argsOptional} -c)
 	endif()
 	if(${args_PAD_BYTES})
 		set(argsOptional ${argsOptional} -pad ${args_PAD_BYTES})

--- a/cmake/ace_functions.cmake
+++ b/cmake/ace_functions.cmake
@@ -280,21 +280,26 @@ endfunction()
 
 function(mergeMods)
 	getToolPath(mod_tool TOOL_MOD_TOOL)
-	set(oneValArgs SAMPLE_PACK TARGET)
-	set(multiValArgs SOURCES DESTINATIONS)
 	set(cmdParams "")
 	cmake_parse_arguments(
-		args "${options}" "${oneValArgs}" "${multiValArgs}" ${ARGN}
+		args
+		"COMPRESS"
+		"SAMPLE_PACK;TARGET"
+		"SOURCES;DESTINATIONS" ${ARGN}
 	)
 
 	if(NOT ("${args_SAMPLE_PACK} " STREQUAL " "))
 		list(APPEND cmdParams -sp ${args_SAMPLE_PACK})
 	endif()
 
+	if(${args_COMPRESS})
+		list(APPEND cmdParams -c)
+	endif()
+
 	list(LENGTH args_SOURCES srcCount)
 	list(LENGTH args_DESTINATIONS dstCount)
 	if(NOT ${srcCount} EQUAL ${dstCount})
-		message(FATAL_ERROR "[mergeMods] SOURCES count doesn't match DESTINATIONS count")
+		message(FATAL_ERROR "[mergeMods] SOURCES count ${srcCount} doesn't match DESTINATIONS count ${dstCount}")
 	endif()
 
 	MATH(EXPR srcCount "${srcCount}-1")

--- a/cmake/ace_functions.cmake
+++ b/cmake/ace_functions.cmake
@@ -326,20 +326,25 @@ endfunction()
 
 function(packDirectory)
 	getToolPath(pak_tool TOOL_PAK_TOOL)
-	set(oneValArgs SOURCE_DIR DEST_FILE TARGET)
-	set(multiValArgs "")
-	set(cmdParams "")
 	cmake_parse_arguments(
-		args "${options}" "${oneValArgs}" "${multiValArgs}" ${ARGN}
+		args
+		"COMPRESS"
+		"SOURCE_DIR;DEST_FILE;TARGET"
+		""
+		${ARGN}
 	)
 
 	toAbsolute(args_SOURCE_DIR)
 	toAbsolute(args_DEST_FILE)
 	FILE(GLOB_RECURSE sourceDirFiles "${args_SOURCE_DIR}/*")
 
+	if(${args_COMPRESS})
+		set(argsOptional ${argsOptional} -c)
+	endif()
+
 	add_custom_command(
 		OUTPUT ${args_DEST_FILE}
-		COMMAND ${TOOL_PAK_TOOL} ${args_SOURCE_DIR} ${args_DEST_FILE}
+		COMMAND ${TOOL_PAK_TOOL} ${args_SOURCE_DIR} ${args_DEST_FILE} ${argsOptional}
 		WORKING_DIRECTORY ${CMAKE_CURRENT_SOURCE_DIR}
 		DEPENDS ${sourceDirFiles}
 	)

--- a/include/ace/managers/memory.h
+++ b/include/ace/managers/memory.h
@@ -40,7 +40,9 @@ extern "C" {
  */
 UBYTE memType(const void *pMem);
 
-ULONG memGetChipSize(void);
+ULONG memGetFreeChipSize(void);
+
+ULONG memGetFreeSize(void);
 
 void _memCreate(void);
 void _memDestroy(void);

--- a/include/ace/managers/ptplayer.h
+++ b/include/ace/managers/ptplayer.h
@@ -60,8 +60,8 @@ typedef struct _tPtplayerMod {
 } tPtplayerMod;
 
 typedef struct tPtplayerSamplePack {
-	ULONG ulSize;
-	UWORD *pData;
+	UBYTE ubSampleCount;
+	tPtplayerSfx pSamples[PTPLAYER_MOD_SAMPLE_COUNT];
 } tPtplayerSamplePack;
 
 typedef void (*tPtplayerCbSongEnd)(void);

--- a/include/ace/managers/system.h
+++ b/include/ace/managers/system.h
@@ -92,6 +92,8 @@ void systemCheckStack(void);
  */
 UWORD systemGetVersion(void);
 
+UBYTE systemIsStartVolumeWritable(void);
+
 //---------------------------------------------------------------------- GLOBALS
 
 extern struct GfxBase *GfxBase;

--- a/include/ace/utils/disk_file.h
+++ b/include/ace/utils/disk_file.h
@@ -21,9 +21,12 @@ typedef enum tDiskFileMode {
  *
  * @param szPath Path to file to be opened.
  * @param eMode File open mode - see tDiskFileMode
+ * @param isUninterrupted Set to 1 if file won't remain opened while
+ * you enable/disable OS or meddle with blitter ownership.
+ * Speeds up the read/write operations.
  * @return File handle on success, zero on failure.
  */
-tFile *diskFileOpen(const char *szPath, tDiskFileMode eMode);
+tFile *diskFileOpen(const char *szPath, tDiskFileMode eMode, UBYTE isUninterrupted);
 
 /**
  * @brief Check whether file at given path exists and is not a directory.

--- a/include/ace/utils/disk_file.h
+++ b/include/ace/utils/disk_file.h
@@ -11,14 +11,19 @@ extern "C" {
 
 #include "file.h"
 
+typedef enum tDiskFileMode {
+	DISK_FILE_MODE_READ,
+	DISK_FILE_MODE_WRITE,
+} tDiskFileMode;
+
 /**
  * @brief Opens the filesystem file for read/write.
  *
  * @param szPath Path to file to be opened.
- * @param szMode File open mode akin to stdio - "r" for read, "w" for write.
+ * @param eMode File open mode - see tDiskFileMode
  * @return File handle on success, zero on failure.
  */
-tFile *diskFileOpen(const char *szPath, const char *szMode);
+tFile *diskFileOpen(const char *szPath, tDiskFileMode eMode);
 
 /**
  * @brief Check whether file at given path exists and is not a directory.

--- a/include/ace/utils/disk_file_private.h
+++ b/include/ace/utils/disk_file_private.h
@@ -22,6 +22,7 @@ DISKFILE_PRIVATE ULONG diskFileRead(void *pData, void *pDest, ULONG ulSize);
 DISKFILE_PRIVATE ULONG diskFileWrite(void *pData, const void *pSrc, ULONG ulSize);
 DISKFILE_PRIVATE ULONG diskFileSeek(void *pData, LONG lPos, WORD wMode);
 DISKFILE_PRIVATE ULONG diskFileGetPos(void *pData);
+DISKFILE_PRIVATE ULONG diskFileGetSize(void *pData);
 DISKFILE_PRIVATE UBYTE diskFileIsEof(void *pData);
 DISKFILE_PRIVATE void diskFileFlush(void *pData);
 

--- a/include/ace/utils/file.h
+++ b/include/ace/utils/file.h
@@ -24,6 +24,7 @@ typedef ULONG (*tCbFileRead)(void *pData, void *pDest, ULONG ulSize);
 typedef ULONG (*tCbFileWrite)(void *pData, const void *pSrc, ULONG ulSize);
 typedef ULONG (*tCbFileSeek)(void *pData, LONG lPos, WORD wMode);
 typedef ULONG (*tCbFileGetPos)(void *pData);
+typedef ULONG (*tCbFileGetSize)(void *pData);
 typedef UBYTE (*tCbFileIsEof)(void *pData);
 typedef void (*tCbFileFlush)(void *pData);
 
@@ -33,6 +34,7 @@ typedef struct tFileCallbacks {
 	tCbFileWrite cbFileWrite;
 	tCbFileSeek cbFileSeek;
 	tCbFileGetPos cbFileGetPos;
+	tCbFileGetSize cbFileGetSize;
 	tCbFileIsEof cbFileIsEof;
 	tCbFileFlush cbFileFlush;
 } tFileCallbacks;

--- a/include/ace/utils/pak_file.h
+++ b/include/ace/utils/pak_file.h
@@ -28,7 +28,7 @@ typedef struct tPakFile {
 	tPakFileEntry *pEntries;
 } tPakFile;
 
-tPakFile *pakFileOpen(const char *szPath);
+tPakFile *pakFileOpen(const char *szPath, UBYTE isUninterrupted);
 
 void pakFileClose(tPakFile *pPakFile);
 

--- a/include/ace/utils/pak_file.h
+++ b/include/ace/utils/pak_file.h
@@ -16,7 +16,8 @@ extern "C" {
 
 typedef struct tPakFileEntry {
 	ULONG ulOffs;
-	ULONG ulSize;
+	ULONG ulSizeUncompressed;
+	ULONG ulSizeData;
 	ULONG ulPathChecksum; // adler32
 } tPakFileEntry;
 

--- a/src/ace/managers/log.c
+++ b/src/ace/managers/log.c
@@ -47,7 +47,7 @@ static UBYTE isWritingToFileAllowed(void) {
 
 void _logOpen(const char *szFilePath) {
 	g_sLogManager.ubShutUp = 1; // Prevent log message for diskFileOpen()
-	g_sLogManager.pFile = szFilePath ? diskFileOpen(szFilePath, DISK_FILE_MODE_WRITE) : 0;
+	g_sLogManager.pFile = szFilePath ? diskFileOpen(szFilePath, DISK_FILE_MODE_WRITE, 0) : 0;
 	g_sLogManager.ubIndent = 0;
 	g_sLogManager.wasLastInline = 0;
 	g_sLogManager.isBlockEmpty = 1;

--- a/src/ace/managers/log.c
+++ b/src/ace/managers/log.c
@@ -47,7 +47,7 @@ static UBYTE isWritingToFileAllowed(void) {
 
 void _logOpen(const char *szFilePath) {
 	g_sLogManager.ubShutUp = 1; // Prevent log message for diskFileOpen()
-	g_sLogManager.pFile = szFilePath ? diskFileOpen(szFilePath, "w") : 0;
+	g_sLogManager.pFile = szFilePath ? diskFileOpen(szFilePath, DISK_FILE_MODE_WRITE) : 0;
 	g_sLogManager.ubIndent = 0;
 	g_sLogManager.wasLastInline = 0;
 	g_sLogManager.isBlockEmpty = 1;

--- a/src/ace/managers/memory.c
+++ b/src/ace/managers/memory.c
@@ -282,6 +282,10 @@ UBYTE memType(const void *pMem) {
 #endif // AMIGA
 }
 
-ULONG memGetChipSize(void) {
+ULONG memGetFreeChipSize(void) {
 	return AvailMem(MEMF_CHIP);
+}
+
+ULONG memGetFreeSize(void) {
+	return AvailMem(MEMF_ANY);
 }

--- a/src/ace/managers/ptplayer.c
+++ b/src/ace/managers/ptplayer.c
@@ -2826,7 +2826,7 @@ void ptplayerSetSampleVolume(UBYTE ubSampleIndex, UBYTE ubVolume) {
 }
 
 tPtplayerMod *ptplayerModCreateFromPath(const char *szPath) {
-	return ptplayerModCreateFromFd(diskFileOpen(szPath, DISK_FILE_MODE_READ));
+	return ptplayerModCreateFromFd(diskFileOpen(szPath, DISK_FILE_MODE_READ, 1));
 }
 
 tPtplayerMod *ptplayerModCreateFromFd(tFile *pFileMod) {
@@ -2933,7 +2933,7 @@ void ptplayerModDestroy(tPtplayerMod *pMod) {
 //-------------------------------------------------------------------------- SFX
 
 tPtplayerSfx *ptplayerSfxCreateFromPath(const char *szPath, UBYTE isFast) {
-	return ptplayerSfxCreateFromFd(diskFileOpen(szPath, DISK_FILE_MODE_READ), isFast);
+	return ptplayerSfxCreateFromFd(diskFileOpen(szPath, DISK_FILE_MODE_READ, 1), isFast);
 }
 
 tPtplayerSfx *ptplayerSfxCreateFromFd(tFile *pFileSfx, UBYTE isFast)
@@ -3283,7 +3283,7 @@ UBYTE ptplayerSfxLengthInFrames(const tPtplayerSfx *pSfx) {
 }
 
 tPtplayerSamplePack *ptplayerSampleDataCreateFromPath(const char *szPath) {
-	return ptplayerSampleDataCreateFromFd(diskFileOpen(szPath, DISK_FILE_MODE_READ));
+	return ptplayerSampleDataCreateFromFd(diskFileOpen(szPath, DISK_FILE_MODE_READ, 1));
 }
 
 tPtplayerSamplePack *ptplayerSampleDataCreateFromFd(tFile *pFileSamples)

--- a/src/ace/managers/ptplayer.c
+++ b/src/ace/managers/ptplayer.c
@@ -3292,6 +3292,7 @@ tPtplayerSamplePack *ptplayerSampleDataCreateFromFd(tFile *pFileSamples)
 	systemUse();
 
 	UBYTE ubVersion;
+	tPtplayerSamplePack *pSamplePack = 0;
 	fileRead(pFileSamples, &ubVersion, sizeof(ubVersion));
 	if(ubVersion != PTPLAYER_SUPPORTED_SAMPLEPACK_VERSION) {
 		// ACE only supports most up to date file version to limit its size
@@ -3302,7 +3303,7 @@ tPtplayerSamplePack *ptplayerSampleDataCreateFromFd(tFile *pFileSamples)
 		goto fail;
 	}
 
-	tPtplayerSamplePack *pSamplePack = memAllocFastClear(sizeof(*pSamplePack));
+	pSamplePack = memAllocFastClear(sizeof(*pSamplePack));
 	if(!pSamplePack) {
 		goto fail;
 	}

--- a/src/ace/managers/ptplayer.c
+++ b/src/ace/managers/ptplayer.c
@@ -2826,7 +2826,7 @@ void ptplayerSetSampleVolume(UBYTE ubSampleIndex, UBYTE ubVolume) {
 }
 
 tPtplayerMod *ptplayerModCreateFromPath(const char *szPath) {
-	return ptplayerModCreateFromFd(diskFileOpen(szPath, "rb"));
+	return ptplayerModCreateFromFd(diskFileOpen(szPath, DISK_FILE_MODE_READ));
 }
 
 tPtplayerMod *ptplayerModCreateFromFd(tFile *pFileMod) {
@@ -2933,7 +2933,7 @@ void ptplayerModDestroy(tPtplayerMod *pMod) {
 //-------------------------------------------------------------------------- SFX
 
 tPtplayerSfx *ptplayerSfxCreateFromPath(const char *szPath, UBYTE isFast) {
-	return ptplayerSfxCreateFromFd(diskFileOpen(szPath, "rb"), isFast);
+	return ptplayerSfxCreateFromFd(diskFileOpen(szPath, DISK_FILE_MODE_READ), isFast);
 }
 
 tPtplayerSfx *ptplayerSfxCreateFromFd(tFile *pFileSfx, UBYTE isFast)
@@ -3283,7 +3283,7 @@ UBYTE ptplayerSfxLengthInFrames(const tPtplayerSfx *pSfx) {
 }
 
 tPtplayerSamplePack *ptplayerSampleDataCreateFromPath(const char *szPath) {
-	return ptplayerSampleDataCreateFromFd(diskFileOpen(szPath, "rb"));
+	return ptplayerSampleDataCreateFromFd(diskFileOpen(szPath, DISK_FILE_MODE_READ));
 }
 
 tPtplayerSamplePack *ptplayerSampleDataCreateFromFd(tFile *pFileSamples)

--- a/src/ace/managers/system.c
+++ b/src/ace/managers/system.c
@@ -69,8 +69,8 @@ static UWORD s_uwOsDmaCon;
 static UWORD s_uwAceDmaCon = 0;
 static UWORD s_uwOsInitialDma;
 
-static UWORD s_ubOsCiaATimerA;
-static UWORD s_ubOsCiaBTimerB;
+static UWORD s_uwOsCiaATimerA;
+static UWORD s_uwOsCiaBTimerB;
 static UBYTE s_pOsCiaIcr[CIA_COUNT], s_pOsCiaCra[CIA_COUNT], s_pOsCiaCrb[CIA_COUNT];
 static UWORD s_pAceCiaTimerA[CIA_COUNT] = {0xFFFF, 0xFFFF}; // as long as possible
 static UWORD s_pAceCiaTimerB[CIA_COUNT] = {0xFFFF, 0xFFFF};
@@ -689,8 +689,8 @@ static void systemOsDisable(void) {
 		g_pCia[CIA_B]->crb = CIACRB_LOAD;
 
 		// Save OS CIA timer values
-		s_ubOsCiaATimerA = ciaGetTimerA(g_pCia[CIA_A]);
-		s_ubOsCiaBTimerB = ciaGetTimerB(g_pCia[CIA_A]);
+		s_uwOsCiaATimerA = ciaGetTimerA(g_pCia[CIA_A]);
+		s_uwOsCiaBTimerB = ciaGetTimerB(g_pCia[CIA_A]);
 
 		// set ACE CIA timers
 		ciaSetTimerA(g_pCia[CIA_A], s_pAceCiaTimerA[CIA_A]);
@@ -1056,8 +1056,8 @@ void systemUse(void) {
 		g_pCia[CIA_B]->crb = 0;
 
 		// Restore old CIA timer A values
-		ciaSetTimerA(g_pCia[CIA_A], s_ubOsCiaATimerA);
-		ciaSetTimerB(g_pCia[CIA_A], s_ubOsCiaBTimerB);
+		ciaSetTimerA(g_pCia[CIA_A], s_uwOsCiaATimerA);
+		ciaSetTimerB(g_pCia[CIA_A], s_uwOsCiaBTimerB);
 
 		// Restore OS's CIA interrupts
 		// According to UAE debugger there's nothing in CIA_A

--- a/src/ace/utils/bitmap.c
+++ b/src/ace/utils/bitmap.c
@@ -121,7 +121,7 @@ fail:
 }
 
 void bitmapLoadFromPath(tBitMap *pBitMap, const char *szPath, UWORD uwStartX, UWORD uwStartY) {
-	return bitmapLoadFromFd(pBitMap, diskFileOpen(szPath, DISK_FILE_MODE_READ), uwStartX, uwStartY);
+	return bitmapLoadFromFd(pBitMap, diskFileOpen(szPath, DISK_FILE_MODE_READ, 1), uwStartX, uwStartY);
 }
 
 void bitmapLoadFromFd(
@@ -252,7 +252,7 @@ void bitmapLoadFromFd(
 }
 
 tBitMap *bitmapCreateFromPath(const char *szPath, UBYTE isFast) {
-	return bitmapCreateFromFd(diskFileOpen(szPath, DISK_FILE_MODE_READ), isFast);
+	return bitmapCreateFromFd(diskFileOpen(szPath, DISK_FILE_MODE_READ, 1), isFast);
 }
 
 tBitMap *bitmapCreateFromFd(tFile *pFile, UBYTE isFast) {
@@ -370,7 +370,7 @@ void bitmapSave(const tBitMap *pBitMap, const char *szPath) {
 	systemUse();
 	logBlockBegin("bitmapSave(pBitMap: %p, szPath: '%s')", pBitMap, szPath);
 
-	tFile *pFile = diskFileOpen(szPath, DISK_FILE_MODE_WRITE);
+	tFile *pFile = diskFileOpen(szPath, DISK_FILE_MODE_WRITE, 1);
 	if(!pFile) {
 		logWrite("ERR: Couldn't save bitmap at '%s'\n", szPath);
 		logBlockEnd("bitmapSave()");
@@ -415,7 +415,7 @@ void bitmapSaveBmp(
 
 	systemUse();
 	UWORD uwWidth = bitmapGetByteWidth(pBitMap) << 3;
-	tFile *pOut = diskFileOpen(szFilePath, DISK_FILE_MODE_WRITE);
+	tFile *pOut = diskFileOpen(szFilePath, DISK_FILE_MODE_WRITE, 1);
 	if(!pOut) {
 		logWrite("ERR: Couldn't save bmp at '%s'\n", szFilePath);
 		logBlockEnd("bitmapSaveBmp()");

--- a/src/ace/utils/bitmap.c
+++ b/src/ace/utils/bitmap.c
@@ -121,7 +121,7 @@ fail:
 }
 
 void bitmapLoadFromPath(tBitMap *pBitMap, const char *szPath, UWORD uwStartX, UWORD uwStartY) {
-	return bitmapLoadFromFd(pBitMap, diskFileOpen(szPath, "rb"), uwStartX, uwStartY);
+	return bitmapLoadFromFd(pBitMap, diskFileOpen(szPath, DISK_FILE_MODE_READ), uwStartX, uwStartY);
 }
 
 void bitmapLoadFromFd(
@@ -252,7 +252,7 @@ void bitmapLoadFromFd(
 }
 
 tBitMap *bitmapCreateFromPath(const char *szPath, UBYTE isFast) {
-	return bitmapCreateFromFd(diskFileOpen(szPath, "rb"), isFast);
+	return bitmapCreateFromFd(diskFileOpen(szPath, DISK_FILE_MODE_READ), isFast);
 }
 
 tBitMap *bitmapCreateFromFd(tFile *pFile, UBYTE isFast) {
@@ -370,7 +370,7 @@ void bitmapSave(const tBitMap *pBitMap, const char *szPath) {
 	systemUse();
 	logBlockBegin("bitmapSave(pBitMap: %p, szPath: '%s')", pBitMap, szPath);
 
-	tFile *pFile = diskFileOpen(szPath, "wb");
+	tFile *pFile = diskFileOpen(szPath, DISK_FILE_MODE_WRITE);
 	if(!pFile) {
 		logWrite("ERR: Couldn't save bitmap at '%s'\n", szPath);
 		logBlockEnd("bitmapSave()");
@@ -415,7 +415,7 @@ void bitmapSaveBmp(
 
 	systemUse();
 	UWORD uwWidth = bitmapGetByteWidth(pBitMap) << 3;
-	tFile *pOut = diskFileOpen(szFilePath, "w");
+	tFile *pOut = diskFileOpen(szFilePath, DISK_FILE_MODE_WRITE);
 	if(!pOut) {
 		logWrite("ERR: Couldn't save bmp at '%s'\n", szFilePath);
 		logBlockEnd("bitmapSaveBmp()");

--- a/src/ace/utils/disk_file.c
+++ b/src/ace/utils/disk_file.c
@@ -140,8 +140,8 @@ DISKFILE_PRIVATE ULONG diskFileSeek(void *pData, LONG lPos, WORD wMode) {
 	if(wMode == SEEK_SET) {
 		LONG lDelta = lPos - diskFileGetPos(pData);
 		if(
-			(lDelta > 0 && lDelta < pDiskFileData->uwBufferFill - pDiskFileData->uwBufferReadPos) ||
-			(lDelta < 0 && -lDelta < pDiskFileData->uwBufferReadPos)
+			(lDelta <= 0 && -lDelta < pDiskFileData->uwBufferReadPos) ||
+			(lDelta > 0 && lDelta < pDiskFileData->uwBufferFill - pDiskFileData->uwBufferReadPos)
 		) {
 			pDiskFileData->uwBufferReadPos += lDelta;
 			return 0;
@@ -167,7 +167,7 @@ DISKFILE_PRIVATE ULONG diskFileSeek(void *pData, LONG lPos, WORD wMode) {
 
 	ULONG ulResult = fseek(pDiskFileData->pFileHandle, lPos, wMode);
 	if(pDiskFileData->uwBufferFill) {
-		logWrite("WARN: slow - read buffer discard");
+		logWrite("WARN: slow - read buffer discard\n");
 		pDiskFileData->uwBufferReadPos = 0;
 		pDiskFileData->uwBufferFill = 0;
 	}

--- a/src/ace/utils/disk_file.c
+++ b/src/ace/utils/disk_file.c
@@ -8,7 +8,7 @@
 #include <ace/managers/log.h>
 #include <ace/utils/disk_file_private.h>
 
-#define DISK_FILE_BUFFER_SIZE 512
+#define DISK_FILE_BUFFER_SIZE 1024
 
 typedef struct tDiskFileData {
 	FILE *pFileHandle;
@@ -74,19 +74,19 @@ DISKFILE_PRIVATE ULONG diskFileRead(void *pData, void *pDest, ULONG ulSize) {
 		for(UWORD i = 0; i < uwBytesToCopy; ++i) {
 			*(pDestBytes++) = pDiskFileData->pBuffer[pDiskFileData->uwBufferReadPos + i];
 		}
-		// memcpy(pDest, &pDiskFileData->pBuffer[pDiskFileData->uwBufferReadPos], uwBytesToCopy);
 		ulReadCount += uwBytesToCopy;
 		pDiskFileData->uwBufferReadPos += uwBytesToCopy;
 		ulSize -= uwBytesToCopy;
 	}
 
-	if(ulSize > DISK_FILE_BUFFER_SIZE) {
+	if(ulSize && ulSize > DISK_FILE_BUFFER_SIZE) {
 		// if remaining data is bigger than buffer, read rest directly
 		systemUse();
 		fileAccessEnable();
 		ULONG ulReadPartSize = fread(pDestBytes, ulSize, 1, pDiskFileData->pFileHandle);
 		pDestBytes += ulReadPartSize;
 		ulReadCount += ulReadPartSize;
+		ulSize -= ulReadPartSize;
 		fileAccessDisable();
 		systemUnuse();
 	}
@@ -111,13 +111,11 @@ DISKFILE_PRIVATE ULONG diskFileRead(void *pData, void *pDest, ULONG ulSize) {
 			for(UWORD i = 0; i < uwBytesToCopy; ++i) {
 				*(pDestBytes++) = pDiskFileData->pBuffer[i];
 			}
-			// memcpy(pDest, &pDiskFileData->pBuffer[pDiskFileData->uwBufferReadPos], uwBytesToCopy);
-				ulReadCount += uwBytesToCopy;
+			ulReadCount += uwBytesToCopy;
 			ulSize -= uwBytesToCopy;
 			pDiskFileData->uwBufferReadPos += uwBytesToCopy;
 		}
 	}
-
 
 	return ulReadCount;
 }

--- a/src/ace/utils/file.c
+++ b/src/ace/utils/file.c
@@ -7,29 +7,6 @@
 #include <ace/managers/system.h>
 #include <ace/managers/log.h>
 
-LONG fileGetSize(tFile *pFile) {
-	// One could use std library to seek to end of file and use ftell,
-	// but SEEK_END is not guaranteed to work.
-	// http://www.cplusplus.com/reference/cstdio/fseek/
-	// On the other hand, Lock/UnLock is bugged on KS1.3 and doesn't allow
-	// for doing Open() on same file after using it.
-	// So I ultimately do it using fseek.
-
-	logBlockBegin("fileGetSize(pFile: %p)", pFile);
-	if(!pFile) {
-		logWrite("ERR: Null file handle\n");
-		logBlockEnd("fileGetSize()");
-		return -1;
-	}
-	LONG lOldPos = fileGetPos(pFile);
-	fileSeek(pFile, 0, SEEK_END);
-	LONG lSize = fileGetPos(pFile);
-	fileSeek(pFile, lOldPos, SEEK_SET);
-
-	logBlockEnd("fileGetSize()");
-	return lSize;
-}
-
 void fileWriteStr(tFile *pFile, const char *szLine) {
 	if(!pFile) {
 		logWrite("ERR: Null file handle\n");
@@ -58,6 +35,10 @@ ULONG fileSeek(tFile *pFile, LONG lPos, WORD wMode) {
 
 ULONG fileGetPos(tFile *pFile) {
 	return diskFileGetPos(pFile);
+}
+
+ULONG fileGetSize(tFile *pFile) {
+	return diskFileGetSize(pFile);
 }
 
 UBYTE fileIsEof(tFile *pFile) {
@@ -108,6 +89,13 @@ ULONG fileGetPos(tFile *pFile) {
 		logWrite("ERR: Null file handle\n");
 	}
 	return pFile->pCallbacks->cbFileGetPos(pFile->pData);
+}
+
+LONG fileGetSize(tFile *pFile) {
+	if(!pFile) {
+		logWrite("ERR: Null file handle\n");
+	}
+	return pFile->pCallbacks->cbFileGetSize(pFile->pData);
 }
 
 UBYTE fileIsEof(tFile *pFile) {

--- a/src/ace/utils/font.c
+++ b/src/ace/utils/font.c
@@ -20,7 +20,7 @@ UBYTE fontGlyphWidth(const tFont *pFont, char c) {
 }
 
 tFont *fontCreateFromPath(const char *szPath) {
-	return fontCreateFromFd(diskFileOpen(szPath, "rb"));
+	return fontCreateFromFd(diskFileOpen(szPath, DISK_FILE_MODE_READ));
 }
 
 tFont *fontCreateFromFd(tFile *pFontFile) {

--- a/src/ace/utils/font.c
+++ b/src/ace/utils/font.c
@@ -20,7 +20,7 @@ UBYTE fontGlyphWidth(const tFont *pFont, char c) {
 }
 
 tFont *fontCreateFromPath(const char *szPath) {
-	return fontCreateFromFd(diskFileOpen(szPath, DISK_FILE_MODE_READ));
+	return fontCreateFromFd(diskFileOpen(szPath, DISK_FILE_MODE_READ, 1));
 }
 
 tFont *fontCreateFromFd(tFile *pFontFile) {

--- a/src/ace/utils/pak_file.c
+++ b/src/ace/utils/pak_file.c
@@ -11,11 +11,48 @@
 #if !defined(ACE_FILE_USE_ONLY_DISK)
 #define ADLER32_MODULO 65521
 
+typedef UBYTE (*tCbCompressReadByte)(UBYTE *pOut, void *pData);
+
+typedef enum tCompressUnpackStateKind {
+	COMPRESS_UNPACK_STATE_KIND_READ_CTL,
+	COMPRESS_UNPACK_STATE_KIND_PROCESS_CTL_BIT,
+	COMPRESS_UNPACK_STATE_KIND_END_CTL,
+	COMPRESS_UNPACK_STATE_KIND_WRITE_RLE,
+	COMPRESS_UNPACK_STATE_KIND_DONE,
+} tCompressUnpackStateKind;
+
+typedef enum tCompressUnpackerResult {
+	COMPRESS_UNPACK_RESULT_BUSY,
+	COMPRESS_UNPACK_RESULT_BUSY_WROTE_BYTE,
+	COMPRESS_UNPACK_RESULT_DONE,
+} tCompressUnpackerResult;
+
+typedef struct tCompressUnpacker {
+	tCompressUnpackStateKind eCurrentState;
+	UBYTE pLookup[0x1000];
+	tCbCompressReadByte cbReadByte;
+	void *pCbData;
+	ULONG ulCompressedSize;
+	ULONG ulUncompressedSize;
+	UBYTE ubCtlByte;
+	UBYTE ubCtlBitIndex;
+	UBYTE ubRlePos;
+	UBYTE ubRleLength;
+	UWORD uwRleStart;
+	UWORD uwLookupPos;
+	ULONG ulUnpackedCount;
+} tCompressUnpacker;
+
 typedef struct tPakFileSubfileData {
 	tPakFile *pPak;
 	ULONG ulPos;
 	UWORD uwFileIndex;
 } tPakFileSubfileData;
+
+typedef struct tPakFileCompressedData {
+	tCompressUnpacker sUnpacker;
+	tFile *pSubfile;
+} tPakFileCompressedData;
 
 static void pakSubfileClose(void *pData);
 static ULONG pakSubfileRead(void *pData, void *pDest, ULONG ulSize);
@@ -24,6 +61,14 @@ static ULONG pakSubfileSeek(void *pData, LONG lPos, WORD wMode);
 static ULONG pakSubfileGetPos(void *pData);
 static UBYTE pakSubfileIsEof(void *pData);
 static void pakSubfileFlush(void *pData);
+
+static void pakCompressedClose(void *pData);
+static ULONG pakCompressedRead(void *pData, void *pDest, ULONG ulSize);
+static ULONG pakCompressedWrite(void *pData, const void *pSrc, ULONG ulSize);
+static ULONG pakCompressedSeek(void *pData, LONG lPos, WORD wMode);
+static ULONG pakCompressedGetPos(void *pData);
+static UBYTE pakCompressedIsEof(void *pData);
+static void pakCompressedFlush(void *pData);
 
 static const tFileCallbacks s_sPakSubfileCallbacks = {
 	.cbFileClose = pakSubfileClose,
@@ -35,7 +80,116 @@ static const tFileCallbacks s_sPakSubfileCallbacks = {
 	.cbFileFlush = pakSubfileFlush,
 };
 
+static const tFileCallbacks s_sPakCompressedCallbacks = {
+	.cbFileClose = pakCompressedClose,
+	.cbFileRead = pakCompressedRead,
+	.cbFileWrite = pakCompressedWrite,
+	.cbFileSeek = pakCompressedSeek,
+	.cbFileGetPos = pakCompressedGetPos,
+	.cbFileIsEof = pakCompressedIsEof,
+	.cbFileFlush = pakCompressedFlush,
+};
+
 //------------------------------------------------------------------ PRIVATE FNS
+
+void compressUnpackerInit(
+	tCompressUnpacker *pUnpacker, tCbCompressReadByte cbReadByte, void *pCbData,
+	ULONG ulCompressedSize, size_t ulUncompressedSize
+) {
+	memset(pUnpacker, 0, sizeof(*pUnpacker));
+	pUnpacker->ulCompressedSize = ulCompressedSize;
+	pUnpacker->ulUncompressedSize = ulUncompressedSize;
+	pUnpacker->cbReadByte = cbReadByte;
+	pUnpacker->pCbData = pCbData;
+}
+
+static void rleTableWrite(UBYTE *pTable, UWORD *pPos, UBYTE ubData) {
+	pTable[*pPos] = ubData;
+	(*pPos)++;
+	(*pPos) &= 0xfff;
+}
+
+static UBYTE rleTableRead(const UBYTE *pTable, UWORD *pPos) {
+	UBYTE ubData;
+
+	ubData = pTable[*pPos];
+	(*pPos)++;
+	(*pPos) &= 0xfff;
+
+	return ubData;
+}
+
+static tCompressUnpackerResult compressUnpackerProcess(
+	tCompressUnpacker *pUnpacker, UBYTE *pOut
+) {
+	// TODO: handle cbReadByte not returning any bytes
+	switch(pUnpacker->eCurrentState) {
+		case COMPRESS_UNPACK_STATE_KIND_READ_CTL:
+			pUnpacker->cbReadByte(&pUnpacker->ubCtlByte, pUnpacker->pCbData);
+			pUnpacker->ubCtlBitIndex = 0;
+			pUnpacker->eCurrentState = COMPRESS_UNPACK_STATE_KIND_PROCESS_CTL_BIT;
+			break;
+
+		case COMPRESS_UNPACK_STATE_KIND_PROCESS_CTL_BIT:
+			if(pUnpacker->ubCtlBitIndex < 8 && pUnpacker->ulUnpackedCount < pUnpacker->ulUncompressedSize) {
+				UBYTE ubBitValue = pUnpacker->ubCtlByte & (1 << pUnpacker->ubCtlBitIndex);
+				pUnpacker->ubCtlBitIndex++;
+				if (ubBitValue) {
+					// Output the next byte and store it in the table
+					UBYTE ubRawByte;
+					pUnpacker->cbReadByte(&ubRawByte, pUnpacker->pCbData);
+					rleTableWrite(pUnpacker->pLookup, &pUnpacker->uwLookupPos, ubRawByte);
+					*pOut = ubRawByte;
+					pUnpacker->ulUnpackedCount++;
+					return COMPRESS_UNPACK_RESULT_BUSY_WROTE_BYTE;
+				}
+				else {
+					UBYTE ubHi, ubLo;
+					pUnpacker->cbReadByte(&ubLo, pUnpacker->pCbData);
+					pUnpacker->cbReadByte(&ubHi, pUnpacker->pCbData);
+					UWORD uwRleCtl = (ubLo << 0) | (ubHi << 8);
+
+					pUnpacker->ubRleLength = ((uwRleCtl & 0xf000) >> 12) + 3;
+					pUnpacker->uwRleStart = uwRleCtl & 0xfff;
+					pUnpacker->ubRlePos = 0;
+					pUnpacker->eCurrentState = COMPRESS_UNPACK_STATE_KIND_WRITE_RLE;
+				}
+			}
+			else {
+				pUnpacker->eCurrentState = COMPRESS_UNPACK_STATE_KIND_END_CTL;
+			}
+			break;
+
+		case COMPRESS_UNPACK_STATE_KIND_END_CTL:
+			if (pUnpacker->ulUnpackedCount >= pUnpacker->ulUncompressedSize) {
+				pUnpacker->eCurrentState = COMPRESS_UNPACK_STATE_KIND_DONE;
+			}
+			else {
+				pUnpacker->eCurrentState = COMPRESS_UNPACK_STATE_KIND_READ_CTL;
+			}
+			break;
+
+		case COMPRESS_UNPACK_STATE_KIND_WRITE_RLE:
+			if(pUnpacker->ubRlePos < pUnpacker->ubRleLength) {
+				UBYTE ubRawByte = rleTableRead(pUnpacker->pLookup, &pUnpacker->uwRleStart);
+				rleTableWrite(pUnpacker->pLookup, &pUnpacker->uwLookupPos, ubRawByte);
+				*pOut = ubRawByte;
+				pUnpacker->ulUnpackedCount++;
+				++pUnpacker->ubRlePos;
+				return COMPRESS_UNPACK_RESULT_BUSY_WROTE_BYTE;
+			}
+			else {
+				pUnpacker->eCurrentState = COMPRESS_UNPACK_STATE_KIND_PROCESS_CTL_BIT;
+			}
+			break;
+
+		case COMPRESS_UNPACK_STATE_KIND_DONE:
+			return COMPRESS_UNPACK_RESULT_DONE;
+			break;
+	}
+
+	return COMPRESS_UNPACK_RESULT_BUSY;
+}
 
 static ULONG adler32Buffer(const UBYTE *pData, ULONG ulDataSize) {
 	ULONG a = 1, b = 0;
@@ -95,13 +249,15 @@ static ULONG pakSubfileSeek(void *pData, LONG lPos, WORD wMode) {
 		pSubfileData->ulPos += lPos;
 	}
 	else if(wMode == FILE_SEEK_END) {
-		pSubfileData->ulPos = pPakEntry->ulSize + lPos;
+		pSubfileData->ulPos = pPakEntry->ulSizeUncompressed + lPos;
 	}
 	pPak->pPrevReadSubfile = 0; // Invalidate cache
 
-	if(pSubfileData->ulPos > pPakEntry->ulSize) {
-		logWrite("ERR: Seek position %lu out of range %lu for pakFile %hu\n", pSubfileData->ulPos, pPakEntry->ulSize, pSubfileData->uwFileIndex);
-		pSubfileData->ulPos = pPakEntry->ulSize;
+	if(pSubfileData->ulPos > pPakEntry->ulSizeUncompressed) {
+		logWrite("ERR: Seek position %lu out of range %lu for pakFile %hu\n",
+			pSubfileData->ulPos, pPakEntry->ulSizeUncompressed, pSubfileData->uwFileIndex
+		);
+		pSubfileData->ulPos = pPakEntry->ulSizeUncompressed;
 		return 0;
 	}
 	return 1;
@@ -116,10 +272,113 @@ static ULONG pakSubfileGetPos(void *pData) {
 static UBYTE pakSubfileIsEof(void *pData) {
 	tPakFileSubfileData *pSubfileData = (tPakFileSubfileData*)pData;
 
-	return pSubfileData->ulPos <= pSubfileData->pPak->pEntries[pSubfileData->uwFileIndex].ulSize;
+	return pSubfileData->ulPos <= pSubfileData->pPak->pEntries[pSubfileData->uwFileIndex].ulSizeUncompressed;
 }
 
 static void pakSubfileFlush(UNUSED_ARG void *pData) {
+	// no-op
+}
+
+static UBYTE pakCompressedReadByte(UBYTE *pOut, void *pData) {
+	tPakFileCompressedData *pCompressedData = (tPakFileCompressedData*)pData;
+	return fileRead(pCompressedData->pSubfile, pOut, 1);
+}
+
+static void pakCompressedClose(void *pData) {
+	tPakFileCompressedData *pCompressedData = (tPakFileCompressedData*)pData;
+	fileClose(pCompressedData->pSubfile);
+	memFree(pCompressedData, sizeof(*pCompressedData));
+}
+
+static ULONG pakCompressedRead(void *pData, void *pDest, ULONG ulSize) {
+	tPakFileCompressedData *pCompressedData = (tPakFileCompressedData*)pData;
+	ULONG ulBytesRead = 0;
+	UBYTE *pDestBytes = pDest;
+
+	while(ulSize) {
+		UBYTE ubUnpacked;
+		tCompressUnpackerResult eUnpackResult = compressUnpackerProcess(
+			&pCompressedData->sUnpacker, &ubUnpacked
+		);
+		if(eUnpackResult == COMPRESS_UNPACK_RESULT_BUSY_WROTE_BYTE) {
+			*(pDestBytes++) = ubUnpacked;
+			++ulBytesRead;
+			--ulSize;
+		}
+		else if(eUnpackResult == COMPRESS_UNPACK_RESULT_DONE) {
+			break;
+		}
+	}
+	return ulBytesRead;
+}
+
+static ULONG pakCompressedWrite(
+	UNUSED_ARG void *pData, UNUSED_ARG const void *pSrc, UNUSED_ARG ULONG ulSize
+) {
+	logWrite("ERR: Unsupported: pakCompressedWrite()\n");
+	return 0;
+}
+
+static ULONG pakCompressedSeek(void *pData, LONG lPos, WORD wMode) {
+	tPakFileCompressedData *pCompressedData = (tPakFileCompressedData*)pData;
+	// seek forward: unpack some bytes to void
+	// seek backward: restart unpacker and unpack some bytes to void
+
+	ULONG ulPosCurrent = pCompressedData->sUnpacker.ulUnpackedCount;
+	ULONG ulPosTarget;
+	ULONG ulFileSize = fileGetSize(pCompressedData->pSubfile);
+	if(wMode == SEEK_CUR) {
+		ulPosTarget = ulPosCurrent + lPos;
+	}
+	else if(wMode == SEEK_END) {
+		ulPosTarget = ulFileSize + lPos;
+	}
+	else { // (wMode == SEEK_SET)
+		ulPosTarget = lPos;
+	}
+
+	if(ulPosTarget > pCompressedData->sUnpacker.ulUncompressedSize) {
+		logWrite(
+			"ERR: Seek position %lu out of range %lu for compressed pakFile\n",
+			ulPosTarget, pCompressedData->sUnpacker.ulUncompressedSize
+		);
+		return 0;
+	}
+
+	if(ulPosTarget == ulFileSize) {
+		pCompressedData->sUnpacker.eCurrentState = COMPRESS_UNPACK_STATE_KIND_DONE;
+		pCompressedData->sUnpacker.ulUnpackedCount = ulFileSize;
+		return 1;
+	}
+
+	if(ulPosTarget < ulPosCurrent) {
+		logWrite("WARN: Huge performance penalty due to going back in compressed file. Do you *really* need to do it?\n");
+		compressUnpackerInit(
+			&pCompressedData->sUnpacker, pakCompressedReadByte, pCompressedData,
+			pCompressedData->sUnpacker.ulCompressedSize,
+			pCompressedData->sUnpacker.ulUncompressedSize
+		);
+	}
+
+	while(pCompressedData->sUnpacker.ulUnpackedCount < ulPosTarget) {
+		UBYTE ubDummy;
+		pakCompressedRead(pData, &ubDummy, 1);
+	}
+
+	return 1;
+}
+
+static ULONG pakCompressedGetPos(void *pData) {
+	tPakFileCompressedData *pCompressedData = (tPakFileCompressedData*)pData;
+	return pCompressedData->sUnpacker.ulUnpackedCount;
+}
+
+static UBYTE pakCompressedIsEof(void *pData) {
+	tPakFileCompressedData *pCompressedData = (tPakFileCompressedData*)pData;
+	return pCompressedData->sUnpacker.ulUnpackedCount >= pCompressedData->sUnpacker.ulUncompressedSize;
+}
+
+static void pakCompressedFlush(UNUSED_ARG void *pData) {
 	// no-op
 }
 
@@ -151,7 +410,8 @@ tPakFile *pakFileOpen(const char *szPath) {
 	for(UWORD i = 0; i < pPakFile->uwFileCount; ++i) {
 		fileRead(pMainFile, &pPakFile->pEntries[i].ulPathChecksum, sizeof(pPakFile->pEntries[i].ulPathChecksum));
 		fileRead(pMainFile, &pPakFile->pEntries[i].ulOffs, sizeof(pPakFile->pEntries[i].ulOffs));
-		fileRead(pMainFile, &pPakFile->pEntries[i].ulSize, sizeof(pPakFile->pEntries[i].ulSize));
+		fileRead(pMainFile, &pPakFile->pEntries[i].ulSizeUncompressed, sizeof(pPakFile->pEntries[i].ulSizeUncompressed));
+		fileRead(pMainFile, &pPakFile->pEntries[i].ulSizeData, sizeof(pPakFile->pEntries[i].ulSizeData));
 	}
 	logWrite("Pak file: %p, file count: %hu\n", pPakFile, pPakFile->uwFileCount);
 
@@ -175,11 +435,13 @@ tFile *pakFileGetFile(tPakFile *pPakFile, const char *szInternalPath) {
 		logBlockEnd("pakFileGetFile()");
 		return 0;
 	}
+	UBYTE isCompressed = pPakFile->pEntries[uwFileIndex].ulSizeUncompressed != pPakFile->pEntries[uwFileIndex].ulSizeData;
 	logWrite(
-		"Subfile index: %hu, offset: %lu, size: %lu\n",
+		"Subfile index: %hu, offset: %lu, size: %lu, compressed: %hhu\n",
 		uwFileIndex,
 		pPakFile->pEntries[uwFileIndex].ulOffs,
-		pPakFile->pEntries[uwFileIndex].ulSize
+		pPakFile->pEntries[uwFileIndex].ulSizeUncompressed,
+		isCompressed
 	);
 
 	// Create tFile, fill subfileData
@@ -193,6 +455,21 @@ tFile *pakFileGetFile(tPakFile *pPakFile, const char *szInternalPath) {
 	tFile *pFile = memAllocFast(sizeof(*pFile));
 	pFile->pCallbacks = &s_sPakSubfileCallbacks;
 	pFile->pData = pSubfileData;
+
+	if(isCompressed) {
+		tPakFileCompressedData *pCompressedData = memAllocFast(sizeof(*pCompressedData));
+		pCompressedData->pSubfile = pFile;
+		compressUnpackerInit(
+			&pCompressedData->sUnpacker, pakCompressedReadByte, pCompressedData,
+			pPakFile->pEntries[uwFileIndex].ulSizeData,
+			pPakFile->pEntries[uwFileIndex].ulSizeUncompressed
+		);
+
+		tFile *pCompressedFile = memAllocFast(sizeof(*pCompressedFile));
+		pCompressedFile->pCallbacks = &s_sPakCompressedCallbacks;
+		pCompressedFile->pData = pCompressedData;
+		pFile = pCompressedFile;
+	}
 
 	logBlockEnd("pakFileGetFile()");
 	return pFile;

--- a/src/ace/utils/pak_file.c
+++ b/src/ace/utils/pak_file.c
@@ -406,9 +406,9 @@ static UWORD pakFileGetFileIndex(const tPakFile *pPakFile, const char *szPath) {
 
 //------------------------------------------------------------------- PUBLIC FNS
 
-tPakFile *pakFileOpen(const char *szPath) {
+tPakFile *pakFileOpen(const char *szPath, UBYTE isUninterrupted) {
 	logBlockBegin("pakFileOpen(szPath: '%s')", szPath);
-	tFile *pMainFile = diskFileOpen(szPath, DISK_FILE_MODE_READ);
+	tFile *pMainFile = diskFileOpen(szPath, DISK_FILE_MODE_READ, isUninterrupted);
 	if(!pMainFile) {
 		logBlockEnd("pakFileOpen()");
 		return 0;

--- a/src/ace/utils/pak_file.c
+++ b/src/ace/utils/pak_file.c
@@ -55,6 +55,7 @@ static ULONG pakSubfileRead(void *pData, void *pDest, ULONG ulSize);
 static ULONG pakSubfileWrite(void *pData, const void *pSrc, ULONG ulSize);
 static ULONG pakSubfileSeek(void *pData, LONG lPos, WORD wMode);
 static ULONG pakSubfileGetPos(void *pData);
+static ULONG pakSubfileGetSize(void *pData);
 static UBYTE pakSubfileIsEof(void *pData);
 static void pakSubfileFlush(void *pData);
 
@@ -63,6 +64,7 @@ static ULONG pakCompressedRead(void *pData, void *pDest, ULONG ulSize);
 static ULONG pakCompressedWrite(void *pData, const void *pSrc, ULONG ulSize);
 static ULONG pakCompressedSeek(void *pData, LONG lPos, WORD wMode);
 static ULONG pakCompressedGetPos(void *pData);
+static ULONG pakCompressedGetSize(void *pData);
 static UBYTE pakCompressedIsEof(void *pData);
 static void pakCompressedFlush(void *pData);
 
@@ -72,6 +74,7 @@ static const tFileCallbacks s_sPakSubfileCallbacks = {
 	.cbFileWrite = pakSubfileWrite,
 	.cbFileSeek = pakSubfileSeek,
 	.cbFileGetPos = pakSubfileGetPos,
+	.cbFileGetSize = pakSubfileGetSize,
 	.cbFileIsEof = pakSubfileIsEof,
 	.cbFileFlush = pakSubfileFlush,
 };
@@ -82,6 +85,7 @@ static const tFileCallbacks s_sPakCompressedCallbacks = {
 	.cbFileWrite = pakCompressedWrite,
 	.cbFileSeek = pakCompressedSeek,
 	.cbFileGetPos = pakCompressedGetPos,
+	.cbFileGetSize = pakCompressedGetSize,
 	.cbFileIsEof = pakCompressedIsEof,
 	.cbFileFlush = pakCompressedFlush,
 };
@@ -253,10 +257,16 @@ static ULONG pakSubfileGetPos(void *pData) {
 	return pSubfileData->ulPos;
 }
 
+static ULONG pakSubfileGetSize(void *pData) {
+	tPakFileSubfileData *pSubfileData = (tPakFileSubfileData*)pData;
+
+	return pSubfileData->pPak->pEntries[pSubfileData->uwFileIndex].ulSizeData;
+}
+
 static UBYTE pakSubfileIsEof(void *pData) {
 	tPakFileSubfileData *pSubfileData = (tPakFileSubfileData*)pData;
 
-	return pSubfileData->ulPos >= pSubfileData->pPak->pEntries[pSubfileData->uwFileIndex].ulSizeData;
+	return pSubfileData->ulPos >= pakSubfileGetSize(pData);
 }
 
 static void pakSubfileFlush(UNUSED_ARG void *pData) {
@@ -345,6 +355,11 @@ static ULONG pakCompressedSeek(void *pData, LONG lPos, WORD wMode) {
 static ULONG pakCompressedGetPos(void *pData) {
 	tPakFileCompressedData *pCompressedData = (tPakFileCompressedData*)pData;
 	return pCompressedData->sUnpacker.ulUnpackedCount;
+}
+
+static ULONG pakCompressedGetSize(void *pData) {
+	tPakFileCompressedData *pCompressedData = (tPakFileCompressedData*)pData;
+	return pCompressedData->sUnpacker.ulUncompressedSize;
 }
 
 static UBYTE pakCompressedIsEof(void *pData) {

--- a/src/ace/utils/pak_file.c
+++ b/src/ace/utils/pak_file.c
@@ -239,15 +239,15 @@ static ULONG pakSubfileSeek(void *pData, LONG lPos, WORD wMode) {
 		pSubfileData->ulPos += lPos;
 	}
 	else if(wMode == FILE_SEEK_END) {
-		pSubfileData->ulPos = pPakEntry->ulSizeUncompressed + lPos;
+		pSubfileData->ulPos = pPakEntry->ulSizeData + lPos;
 	}
 	pPak->pPrevReadSubfile = 0; // Invalidate cache
 
-	if(pSubfileData->ulPos > pPakEntry->ulSizeUncompressed) {
+	if(pSubfileData->ulPos > pPakEntry->ulSizeData) {
 		logWrite("ERR: Seek position %lu out of range %lu for pakFile %hu\n",
-			pSubfileData->ulPos, pPakEntry->ulSizeUncompressed, pSubfileData->uwFileIndex
+			pSubfileData->ulPos, pPakEntry->ulSizeData, pSubfileData->uwFileIndex
 		);
-		pSubfileData->ulPos = pPakEntry->ulSizeUncompressed;
+		pSubfileData->ulPos = pPakEntry->ulSizeData;
 		return 0;
 	}
 	return 1;

--- a/src/ace/utils/pak_file.c
+++ b/src/ace/utils/pak_file.c
@@ -55,21 +55,21 @@ typedef struct tPakFileCompressedData {
 
 static void pakSubfileClose(void *pData);
 static ULONG pakSubfileRead(void *pData, void *pDest, ULONG ulSize);
-static ULONG pakSubfileWrite(void *pData, const void *pSrc, ULONG ulSize);
+static ULONG pakSubfileWrite(UNUSED_ARG void *pData, UNUSED_ARG const void *pSrc, UNUSED_ARG ULONG ulSize);
 static ULONG pakSubfileSeek(void *pData, LONG lPos, WORD wMode);
 static ULONG pakSubfileGetPos(void *pData);
 static ULONG pakSubfileGetSize(void *pData);
 static UBYTE pakSubfileIsEof(void *pData);
-static void pakSubfileFlush(void *pData);
+static void pakSubfileFlush(UNUSED_ARG void *pData);
 
 static void pakCompressedClose(void *pData);
 static ULONG pakCompressedRead(void *pData, void *pDest, ULONG ulSize);
-static ULONG pakCompressedWrite(void *pData, const void *pSrc, ULONG ulSize);
+static ULONG pakCompressedWrite(UNUSED_ARG void *pData, UNUSED_ARG const void *pSrc, UNUSED_ARG ULONG ulSize);
 static ULONG pakCompressedSeek(void *pData, LONG lPos, WORD wMode);
 static ULONG pakCompressedGetPos(void *pData);
 static ULONG pakCompressedGetSize(void *pData);
 static UBYTE pakCompressedIsEof(void *pData);
-static void pakCompressedFlush(void *pData);
+static void pakCompressedFlush(UNUSED_ARG void *pData);
 
 static const tFileCallbacks s_sPakSubfileCallbacks = {
 	.cbFileClose = pakSubfileClose,
@@ -205,7 +205,7 @@ static ULONG adler32Buffer(const UBYTE *pData, ULONG ulDataSize) {
 	return (b << 16) | a;
 }
 
-static void pakSubfileClose(UNUSED_ARG void *pData) {
+static void pakSubfileClose(void *pData) {
 	tPakFileSubfileData *pSubfileData = (tPakFileSubfileData*)pData;
 
 	memFree(pSubfileData, sizeof(*pSubfileData));

--- a/src/ace/utils/pak_file.c
+++ b/src/ace/utils/pak_file.c
@@ -408,7 +408,7 @@ static UWORD pakFileGetFileIndex(const tPakFile *pPakFile, const char *szPath) {
 
 tPakFile *pakFileOpen(const char *szPath) {
 	logBlockBegin("pakFileOpen(szPath: '%s')", szPath);
-	tFile *pMainFile = diskFileOpen(szPath, "rb");
+	tFile *pMainFile = diskFileOpen(szPath, DISK_FILE_MODE_READ);
 	if(!pMainFile) {
 		logBlockEnd("pakFileOpen()");
 		return 0;

--- a/src/ace/utils/pak_file.c
+++ b/src/ace/utils/pak_file.c
@@ -92,7 +92,11 @@ void compressUnpackerInit(
 	tCompressUnpacker *pUnpacker, ULONG ulCompressedSize, size_t ulUncompressedSize,
 	void *pSubfileData
 ) {
-	memset(pUnpacker, 0, sizeof(*pUnpacker));
+	pUnpacker->ulUnpackedCount = 0;
+	pUnpacker->uwLookupPos = 0;
+	pUnpacker->ubUnpackedChunkPos = 0;
+	pUnpacker->ubUnpackedChunkSize = 0;
+
 	pUnpacker->ulCompressedSize = ulCompressedSize;
 	pUnpacker->ulUncompressedSize = ulUncompressedSize;
 	pUnpacker->pSubfileData = pSubfileData;

--- a/src/ace/utils/pak_file.c
+++ b/src/ace/utils/pak_file.c
@@ -308,7 +308,7 @@ static ULONG pakCompressedSeek(void *pData, LONG lPos, WORD wMode) {
 
 	ULONG ulPosCurrent = pCompressedData->sUnpacker.ulUnpackedCount;
 	ULONG ulPosTarget;
-	ULONG ulFileSize = fileGetSize(pCompressedData->pSubfile);
+	ULONG ulFileSize = pCompressedData->sUnpacker.ulUncompressedSize;
 	if(wMode == SEEK_CUR) {
 		ulPosTarget = ulPosCurrent + lPos;
 	}

--- a/src/ace/utils/pak_file.c
+++ b/src/ace/utils/pak_file.c
@@ -136,10 +136,9 @@ static tCompressUnpackerResult compressUnpackerProcess(
 					return COMPRESS_UNPACK_RESULT_BUSY_WROTE_BYTE;
 				}
 				else {
-					UBYTE ubHi, ubLo;
-					pakSubfileRead(pUnpacker->pSubfileData, &ubLo, 1);
-					pakSubfileRead(pUnpacker->pSubfileData, &ubHi, 1);
-					UWORD uwRleCtl = (ubLo << 0) | (ubHi << 8);
+					UWORD uwRleCtl;
+					pakSubfileRead(pUnpacker->pSubfileData, &uwRleCtl, 2);
+					uwRleCtl = rol16(uwRleCtl, 8);
 
 					pUnpacker->ubRleLength = ((uwRleCtl & 0xf000) >> 12) + 3;
 					pUnpacker->uwRleStart = uwRleCtl & 0xfff;

--- a/src/ace/utils/pak_file.c
+++ b/src/ace/utils/pak_file.c
@@ -21,8 +21,11 @@ typedef enum tCompressUnpackStateKind {
 	COMPRESS_UNPACK_STATE_KIND_DONE,
 } tCompressUnpackStateKind;
 
-#define UNPACKER_PACKED_BUFFER_SIZE (8 * 2 + 1)
-#define UNPACKER_UNPACKED_BUFFER_SIZE (8 * (15+3))
+#define UNPACKER_CTL_BITS 8
+#define UNPACKER_RLE_CTL_BYTES 2
+#define UNPACKER_RLE_MAX_LENGTH (15 + 3)
+#define UNPACKER_PACKED_BUFFER_SIZE (UNPACKER_CTL_BITS * UNPACKER_RLE_CTL_BYTES + (UNPACKER_CTL_BITS / 8))
+#define UNPACKER_UNPACKED_BUFFER_SIZE (UNPACKER_CTL_BITS * UNPACKER_RLE_MAX_LENGTH)
 
 typedef struct tCompressUnpacker {
 	void *pSubfileData;
@@ -147,7 +150,7 @@ static WORD compressUnpackerReadNext(tCompressUnpacker *pUnpacker) {
 	// Decode next portion of data
 	pPackedCurrent = &pUnpacker->pPacked[0];
 	UBYTE ubCtl = *(pPackedCurrent++);
-	UBYTE ubBits = 8;
+	UBYTE ubBits = UNPACKER_CTL_BITS;
 	UBYTE *pUnpacked = pUnpacker->pUnpacked;
 
 	while(ubBits--) {

--- a/src/ace/utils/palette.c
+++ b/src/ace/utils/palette.c
@@ -8,7 +8,7 @@
 #include <ace/utils/disk_file.h>
 
 void paletteLoadFromPath(const char *szPath, UWORD *pPalette, UBYTE ubMaxLength) {
-	return paletteLoadFromFd(diskFileOpen(szPath, "rb"), pPalette, ubMaxLength);
+	return paletteLoadFromFd(diskFileOpen(szPath, DISK_FILE_MODE_READ), pPalette, ubMaxLength);
 }
 
 void paletteLoadFromFd(tFile *pFile, UWORD *pPalette, UBYTE ubMaxLength) {
@@ -102,7 +102,7 @@ void paletteSave(UWORD *pPalette, UBYTE ubColorCnt, char *szPath) {
 		pPalette, ubColorCnt, szPath
 	);
 
-	tFile *pFile = diskFileOpen(szPath, "wb");
+	tFile *pFile = diskFileOpen(szPath, DISK_FILE_MODE_WRITE);
 	if(!pFile) {
 		logWrite("ERR: Can't write file\n");
 		logBlockEnd("paletteSave()");

--- a/src/ace/utils/palette.c
+++ b/src/ace/utils/palette.c
@@ -8,7 +8,7 @@
 #include <ace/utils/disk_file.h>
 
 void paletteLoadFromPath(const char *szPath, UWORD *pPalette, UBYTE ubMaxLength) {
-	return paletteLoadFromFd(diskFileOpen(szPath, DISK_FILE_MODE_READ), pPalette, ubMaxLength);
+	return paletteLoadFromFd(diskFileOpen(szPath, DISK_FILE_MODE_READ, 1), pPalette, ubMaxLength);
 }
 
 void paletteLoadFromFd(tFile *pFile, UWORD *pPalette, UBYTE ubMaxLength) {
@@ -102,7 +102,7 @@ void paletteSave(UWORD *pPalette, UBYTE ubColorCnt, char *szPath) {
 		pPalette, ubColorCnt, szPath
 	);
 
-	tFile *pFile = diskFileOpen(szPath, DISK_FILE_MODE_WRITE);
+	tFile *pFile = diskFileOpen(szPath, DISK_FILE_MODE_WRITE, 1);
 	if(!pFile) {
 		logWrite("ERR: Can't write file\n");
 		logBlockEnd("paletteSave()");

--- a/tools/src/audio_conv.cpp
+++ b/tools/src/audio_conv.cpp
@@ -16,6 +16,7 @@ void printUsage(const std::string &szAppName) {
 	print("\tinPath      Path to supported file format\n");
 	print("Extra options:\n");
 	print("\t-o outPath  Specify output file path. If ommited, it will perform default conversion\n");
+	print("\t-c          Enable compression for output file\n");
 	print("\t-d N        Specify amplitude division. Useful for some audio-mixing libraries\n");
 	print("\t-cd N       Check if sound effect fits max amplitude divided by specified factor and raise error otherwise. Useful for some audio-mixing libraries\n");
 	print("\t-strict     Treat warinings as errors (recommended)\n");
@@ -39,6 +40,7 @@ int main(int lArgCount, const char *pArgs[]) {
 		return EXIT_FAILURE;
 	}
 
+	bool isCompressed = false;
 	bool isStrict = false;
 	bool isNormalizing = false;
 	std::uint8_t ubDivisor = 1;
@@ -52,6 +54,9 @@ int main(int lArgCount, const char *pArgs[]) {
 		std::string_view Arg = pArgs[ArgIndex];
 		if(Arg == "-o"sv && ArgIndex < lArgCount -1) {
 			szOutput = pArgs[++ArgIndex];
+		}
+		else if(Arg == "-c"sv) {
+			isCompressed = true;
 		}
 		else if(Arg == "-d"sv && ArgIndex < lArgCount -1) {
 			ubDivisor = uint8_t(std::stoul(pArgs[++ArgIndex]));
@@ -171,7 +176,7 @@ int main(int lArgCount, const char *pArgs[]) {
 			auto PartOutPath = fmt::format(FMT_STRING("{}_{}.{}"), BaseOutputPath, ubPart, szOutExt);
 			fmt::print("Writing to {}\n", PartOutPath);
 			if(szOutExt == "sfx") {
-				In.toSfx(PartOutPath);
+				In.toSfx(PartOutPath, isCompressed);
 			}
 			else {
 				nLog::error("Output file type not supported: {}", szInExt);
@@ -186,7 +191,7 @@ int main(int lArgCount, const char *pArgs[]) {
 		// Save to output
 		fmt::print("Writing to {}...\n", szOutput);
 		if(szOutExt == "sfx") {
-			In.toSfx(szOutput);
+			In.toSfx(szOutput, isCompressed);
 		}
 		else {
 			nLog::error("Output file type not supported: {}", szInExt);

--- a/tools/src/audio_conv.cpp
+++ b/tools/src/audio_conv.cpp
@@ -34,7 +34,7 @@ int main(int lArgCount, const char *pArgs[]) {
 
 	std::uint8_t ubMandatoryArgCnt = 2;
 
-	if(lArgCount < ubMandatoryArgCnt) {
+	if(lArgCount - 1 < ubMandatoryArgCnt) {
 		nLog::error("Too few arguments, expected {}", ubMandatoryArgCnt);
 		printUsage(pArgs[0]);
 		return EXIT_FAILURE;

--- a/tools/src/audio_conv.cpp
+++ b/tools/src/audio_conv.cpp
@@ -176,7 +176,9 @@ int main(int lArgCount, const char *pArgs[]) {
 			auto PartOutPath = fmt::format(FMT_STRING("{}_{}.{}"), BaseOutputPath, ubPart, szOutExt);
 			fmt::print("Writing to {}\n", PartOutPath);
 			if(szOutExt == "sfx") {
-				In.toSfx(PartOutPath, isCompressed);
+				if(!In.toSfx(PartOutPath, isCompressed)) {
+					return EXIT_FAILURE;
+				}
 			}
 			else {
 				nLog::error("Output file type not supported: {}", szInExt);
@@ -191,7 +193,9 @@ int main(int lArgCount, const char *pArgs[]) {
 		// Save to output
 		fmt::print("Writing to {}...\n", szOutput);
 		if(szOutExt == "sfx") {
-			In.toSfx(szOutput, isCompressed);
+			if(!In.toSfx(szOutput, isCompressed)) {
+				return EXIT_FAILURE;
+			}
 		}
 		else {
 			nLog::error("Output file type not supported: {}", szInExt);

--- a/tools/src/common/compress.cpp
+++ b/tools/src/common/compress.cpp
@@ -72,14 +72,13 @@ void compressUnpackerInit(
 	pUnpacker->ulCompressedSize = ulCompressedSize;
 	pUnpacker->ulUncompressedSize = ulUncompressedSize;
 	pUnpacker->isVerbose = isVerbose;
+	if(pUnpacker->isVerbose) fmt::println("Decompress start");
 }
 
 tCompressUnpackResult compressUnpackerProcess(
 	tCompressUnpacker *pUnpacker, std::uint8_t *pOut
 )
 {
-	if(pUnpacker->isVerbose) fmt::println("Decompress start");
-
 	switch(pUnpacker->eCurrentState) {
 		case COMPRESS_UNPACK_STATE_KIND_READ_CTL:
 			pUnpacker->ulCtlOffset = pUnpacker->ulReadOffset;

--- a/tools/src/common/compress.cpp
+++ b/tools/src/common/compress.cpp
@@ -1,0 +1,187 @@
+#include "../common/compress.hpp"
+#include <cmath>
+#include <fmt/format.h>
+
+static constexpr auto s_RleMinLength = 3u;
+static constexpr auto s_RleMaxLength = 18u;
+
+static uint8_t rleTableRead(const uint8_t *table, unsigned *index)
+{
+	uint8_t byte;
+
+	byte = table[*index];
+	(*index)++;
+	(*index) &= 0xfff;
+
+	return byte;
+}
+
+static bool rleTableFind(
+	const uint8_t *table, std::uint16_t table_index,
+	const uint8_t *data, size_t data_size,
+	std::uint16_t *index, std::uint8_t *length
+)
+{
+	*index = 0;
+	*length = 0;
+	unsigned int seq_len;
+	bool isFound = false;
+	for (auto i = 0u; i < 0x1000; i++) {
+		for (seq_len = 0u; seq_len < data_size; seq_len++) {
+			auto offset = i + seq_len;
+			if (table[offset & 0xfff] != data[seq_len]) {
+				break;
+			}
+
+			/*
+			 * Don't return RLE runs that are in the area of the table that
+			 * will be written to, since the values will change.
+			 */
+			if (
+				(i >= table_index && i <= table_index + seq_len) ||
+				(offset >= table_index && offset <= table_index + seq_len)
+			) {
+				seq_len = 0;
+				break;
+			}
+		}
+		if (seq_len >= s_RleMinLength) {
+			if(seq_len > *length) {
+				*index = i;
+				*length = seq_len;
+				isFound = true;
+			}
+		}
+	}
+
+	return isFound;
+}
+
+static void rleTableWrite(uint8_t *table, unsigned *index, uint8_t byte)
+{
+	table[*index] = byte;
+	(*index)++;
+	(*index) &= 0xfff;
+}
+
+void compressUnpack(
+	const uint8_t *pSrc, size_t src_size,
+	uint8_t *pDst, size_t dst_size, bool isVerbose
+)
+{
+	unsigned bit, i, count, src_offset = 0, dst_offset = 0, table_index = 0, rle_index;
+	uint8_t table[0x1000] = {0};
+	uint16_t word;
+	uint8_t ctrl_byte, byte;
+
+	if(isVerbose) fmt::println("Decompress start");
+	while (dst_offset < dst_size) {
+		auto ctl_offset = src_offset;
+		ctrl_byte = pSrc[src_offset++];
+		for (bit = 0; bit < 8; bit++) {
+			if (dst_offset >= dst_size) {
+				break;
+			}
+
+			if (ctrl_byte & (1 << bit)) {
+				/* Output the next byte and store it in the table */
+				byte = pSrc[src_offset++];
+				if(isVerbose) fmt::println("byte at {}: {:02X}", src_offset - 1, byte);
+				pDst[dst_offset++] = byte;
+				rleTableWrite(table, &table_index, byte);
+			}
+			else {
+				/*
+				 *
+				 */
+				word = (pSrc[src_offset + 0] << 0) | (pSrc[src_offset + 1] << 8);
+				src_offset += 2;
+
+				count = ((word & 0xf000) >> 12) + 3;
+				rle_index = word & 0xfff;
+
+				if(isVerbose) fmt::print(
+					"sequence at {}, word: {:04X}, len: {}, index: {}, sequence:",
+					src_offset - 2, word, count, rle_index
+				);
+
+				for (i = 0; i < count; i++) {
+					byte = rleTableRead(table, &rle_index);
+					if(isVerbose) fmt::print(" {:02X}", byte);
+					rleTableWrite(table, &table_index, byte);
+					pDst[dst_offset++] = byte;
+				}
+				if(isVerbose) fmt::print("\n");
+			}
+		}
+		if(isVerbose) fmt::println("used ctl at {}: {:02X}", ctl_offset, ctrl_byte);
+	}
+	if(isVerbose) fmt::println("Decompress done");
+}
+
+size_t compressPack(
+	const uint8_t *src, size_t src_size,
+	uint8_t *dst, size_t dst_size, bool isVerbose
+) {
+	if(isVerbose) fmt::println("Compress start, size {}", src_size);
+	uint8_t table[0x1000] = {0}, byte;
+	unsigned i, bit, src_offset = 0, dst_offset = 0, table_index = 0, ctrl_byte_offset;
+	std::uint16_t rle_index;
+	std::uint8_t rle_len;
+	uint16_t word;
+	bool found;
+
+	while (src_offset < src_size) {
+		/* Write a place-holder control byte */
+		ctrl_byte_offset = dst_offset++;
+		dst[ctrl_byte_offset] = 0;
+
+		for (bit = 0; bit < 8; bit++) {
+			if (src_offset >= src_size) {
+				break;
+			}
+
+			/* Try to find an repeated sequence */
+			found = rleTableFind(
+				table, table_index, &src[src_offset],
+				std::min<std::size_t>(src_size - src_offset, s_RleMaxLength),
+				&rle_index, &rle_len
+			);
+			if (found) {
+				/*
+				 * RLE sequence found. Encode a 16-bit word for length
+				 * and index. Control byte flag is not set.
+				 */
+				word = ((rle_len - 3) & 0xf) << 12;
+				word |= rle_index & 0xfff;
+
+				if(isVerbose) fmt::println(
+					"sequence at {}, word: {:04X}, len: {}, index: {}, sequence: {:02X}",
+					dst_offset, word, rle_len, rle_index,
+					fmt::join(&src[src_offset], &src[src_offset + rle_len], " ")
+				);
+				dst[dst_offset++] = std::uint8_t(word);
+				dst[dst_offset++] = word >> 8;
+
+				for (i = 0; i < rle_len; i++) {
+					rleTableWrite(table, &table_index, src[src_offset++]);
+				}
+			}
+			else {
+				/*
+				 * No sequence found. Encode the byte directly.
+				 * Control byte flag is set.
+				 */
+				dst[ctrl_byte_offset] |= (1 << bit);
+				byte = src[src_offset++];
+				if(isVerbose) fmt::println("byte at {}: {:02X}", dst_offset, byte);
+				dst[dst_offset++] = byte;
+				rleTableWrite(table, &table_index, byte);
+			}
+		}
+		if(isVerbose) fmt::println("used ctl at {}: {:02X}", ctrl_byte_offset, dst[ctrl_byte_offset]);
+	}
+
+	if(isVerbose) fmt::println("compress done, length: {}", dst_offset);
+	return dst_offset;
+}

--- a/tools/src/common/compress.hpp
+++ b/tools/src/common/compress.hpp
@@ -18,38 +18,36 @@ enum tCompressUnpackResult {
 	COMPRESS_UNPACK_RESULT_DONE,
 };
 
-struct tCompressUnpackState {
+struct tCompressUnpacker {
 	tCompressUnpackStateKind eCurrentState;
-	std::uint8_t table[0x1000];
+	std::uint8_t pLookup[0x1000];
 	const std::uint8_t *pCompressed;
 	std::size_t ulCompressedSize;
 	std::size_t ulUncompressedSize;
 	bool isVerbose;
-	unsigned int bit;
-	unsigned int rlePos;
-	unsigned int rleLength;
-	unsigned int src_offset;
-	unsigned int dst_offset;
-	unsigned int table_index;
-	unsigned int rleIndex;
-	unsigned int ctl_offset;
-	std::uint16_t word;
-	std::uint8_t ctrl_byte;
-	std::uint8_t byte;
+	std::uint8_t ubCtlByte;
+	std::uint8_t ubCtlBitIndex;
+	std::uint8_t ubRlePos;
+	std::uint8_t ubRleLength;
+	std::uint16_t uwRleStart;
+	std::uint16_t uwLookupPos;
+	std::uint32_t ulReadOffset;
+	std::uint32_t ulWriteOffset;
+	std::uint32_t ulCtlOffset;
 };
 
-size_t compressPack(
-	const uint8_t *pSrc, size_t srcSize, uint8_t *pDst, size_t dstSize,
-	bool isVerbose = false
+std::uint32_t compressPack(
+	const uint8_t *pSrc, std::uint32_t ulSrcSize,
+	uint8_t *pDest, bool isVerbose = false
 );
 
-void compressUnpackStateInit(
-	tCompressUnpackState *pState, const uint8_t *pSrc, size_t srcSize,
-	size_t dstSize, bool isVerbose = false
+void compressUnpackerInit(
+	tCompressUnpacker *pUnpacker, const uint8_t *pCompressed, size_t ulCompressedSize,
+	size_t ulUncompressedSize, bool isVerbose = false
 );
 
-tCompressUnpackResult compressUnpackProcess(
-	tCompressUnpackState *State, std::uint8_t *pOut
+tCompressUnpackResult compressUnpackerProcess(
+	tCompressUnpacker *State, std::uint8_t *pOut
 );
 
 #endif // _ACE_TOOLS_COMMON_COMPRESS_H_

--- a/tools/src/common/compress.hpp
+++ b/tools/src/common/compress.hpp
@@ -2,15 +2,37 @@
 #define _ACE_TOOLS_COMMON_COMPRESS_H_
 
 #include <cstdint>
+#include <cstddef>
+
+struct tCompressUnpackState {
+	std::uint8_t table[0x1000];
+	const std::uint8_t *pSrc;
+	std::size_t srcSize;
+	std::uint8_t *pDst;
+	std::size_t dstSize;
+	bool isVerbose;
+	unsigned int bit;
+	unsigned int rlePos;
+	unsigned int rleLength;
+	unsigned int src_offset;
+	unsigned int dst_offset;
+	unsigned int table_index;
+	unsigned int rleIndex;
+	std::uint16_t word;
+	std::uint8_t ctrl_byte;
+	std::uint8_t byte;
+};
 
 size_t compressPack(
 	const uint8_t *pSrc, size_t srcSize, uint8_t *pDst, size_t dstSize,
 	bool isVerbose = false
 );
 
-void compressUnpack(
-	const uint8_t *pSrc, size_t srcSize, uint8_t *pDst, size_t dstSize,
-	bool isVerbose = false
+void compressUnpackStateInit(
+	tCompressUnpackState *pState, const uint8_t *pSrc, size_t srcSize,
+	uint8_t *pDst, size_t dstSize, bool isVerbose = false
 );
+
+void compressUnpackProcess(tCompressUnpackState *State);
 
 #endif // _ACE_TOOLS_COMMON_COMPRESS_H_

--- a/tools/src/common/compress.hpp
+++ b/tools/src/common/compress.hpp
@@ -4,12 +4,26 @@
 #include <cstdint>
 #include <cstddef>
 
+enum tCompressUnpackStateKind {
+	COMPRESS_UNPACK_STATE_KIND_READ_CTL,
+	COMPRESS_UNPACK_STATE_KIND_PROCESS_CTL_BIT,
+	COMPRESS_UNPACK_STATE_KIND_END_CTL,
+	COMPRESS_UNPACK_STATE_KIND_WRITE_RLE,
+	COMPRESS_UNPACK_STATE_KIND_DONE,
+};
+
+enum tCompressUnpackResult {
+	COMPRESS_UNPACK_RESULT_BUSY,
+	COMPRESS_UNPACK_RESULT_BUSY_WROTE_BYTE,
+	COMPRESS_UNPACK_RESULT_DONE,
+};
+
 struct tCompressUnpackState {
+	tCompressUnpackStateKind eCurrentState;
 	std::uint8_t table[0x1000];
-	const std::uint8_t *pSrc;
-	std::size_t srcSize;
-	std::uint8_t *pDst;
-	std::size_t dstSize;
+	const std::uint8_t *pCompressed;
+	std::size_t ulCompressedSize;
+	std::size_t ulUncompressedSize;
 	bool isVerbose;
 	unsigned int bit;
 	unsigned int rlePos;
@@ -18,6 +32,7 @@ struct tCompressUnpackState {
 	unsigned int dst_offset;
 	unsigned int table_index;
 	unsigned int rleIndex;
+	unsigned int ctl_offset;
 	std::uint16_t word;
 	std::uint8_t ctrl_byte;
 	std::uint8_t byte;
@@ -30,9 +45,11 @@ size_t compressPack(
 
 void compressUnpackStateInit(
 	tCompressUnpackState *pState, const uint8_t *pSrc, size_t srcSize,
-	uint8_t *pDst, size_t dstSize, bool isVerbose = false
+	size_t dstSize, bool isVerbose = false
 );
 
-void compressUnpackProcess(tCompressUnpackState *State);
+tCompressUnpackResult compressUnpackProcess(
+	tCompressUnpackState *State, std::uint8_t *pOut
+);
 
 #endif // _ACE_TOOLS_COMMON_COMPRESS_H_

--- a/tools/src/common/compress.hpp
+++ b/tools/src/common/compress.hpp
@@ -1,0 +1,16 @@
+#ifndef _ACE_TOOLS_COMMON_COMPRESS_H_
+#define _ACE_TOOLS_COMMON_COMPRESS_H_
+
+#include <cstdint>
+
+size_t compressPack(
+	const uint8_t *pSrc, size_t srcSize, uint8_t *pDst, size_t dstSize,
+	bool isVerbose = false
+);
+
+void compressUnpack(
+	const uint8_t *pSrc, size_t srcSize, uint8_t *pDst, size_t dstSize,
+	bool isVerbose = false
+);
+
+#endif // _ACE_TOOLS_COMMON_COMPRESS_H_

--- a/tools/src/common/sfx.cpp
+++ b/tools/src/common/sfx.cpp
@@ -51,7 +51,7 @@ tSfx::tSfx(const tWav &Wav, bool isStrict):
 bool tSfx::toSfx(const std::string &szPath, bool isCompress) const {
 	std::ofstream FileOut(szPath, std::ios::binary);
 
-	const std::uint8_t ubVersion = 1;
+	const std::uint8_t ubVersion = 2;
 	const std::uint16_t uwWordLength = nEndian::toBig16(uint16_t(m_vData.size() / 2));
 	const std::uint16_t uwSampleReateHz = nEndian::toBig16(m_ulFreq);
 

--- a/tools/src/common/sfx.h
+++ b/tools/src/common/sfx.h
@@ -14,7 +14,7 @@ public:
 
 	tSfx(const tWav &Wav, bool isStrict);
 
-	bool toSfx(const std::string &szPath) const;
+	bool toSfx(const std::string &szPath, bool isCompress) const;
 
 	bool isEmpty(void) const;
 

--- a/tools/src/common/sfx.h
+++ b/tools/src/common/sfx.h
@@ -7,6 +7,7 @@
 
 #include "wav.h"
 #include <string>
+#include <span>
 
 class tSfx {
 public:
@@ -33,6 +34,8 @@ public:
 	void padContents(std::uint8_t ubAlignment);
 
 	tSfx splitAfter(std::uint32_t ulSamples);
+
+	static std::vector<uint8_t> compressLosslessDpcm(std::span<const int8_t> Uncompressed);
 
 private:
 	std::uint32_t m_ulFreq;

--- a/tools/src/common/sfx.h
+++ b/tools/src/common/sfx.h
@@ -36,6 +36,7 @@ public:
 	tSfx splitAfter(std::uint32_t ulSamples);
 
 	static std::vector<uint8_t> compressLosslessDpcm(std::span<const int8_t> Uncompressed);
+	static std::vector<int8_t> decompressLosslessDpcm(const std::vector<uint8_t> &vCompressed, std::uint32_t ulDecompressedSize);
 
 private:
 	std::uint32_t m_ulFreq;

--- a/tools/src/pak_tool.cpp
+++ b/tools/src/pak_tool.cpp
@@ -6,6 +6,7 @@
 #include <fstream>
 #include <filesystem>
 #include <vector>
+#include <algorithm>
 #include "common/logging.h"
 #include "common/fs.h"
 #include "common/endian.h"

--- a/tools/src/pak_tool.cpp
+++ b/tools/src/pak_tool.cpp
@@ -127,7 +127,7 @@ int main(int lArgCount, const char *pArgs[])
 						break;
 					}
 					if(eResult == COMPRESS_UNPACK_RESULT_BUSY_WROTE_BYTE) {
-						vDecompressed[UnpackState.ulWriteOffset] = ubRead;
+						vDecompressed[UnpackState.ulWriteOffset - 1] = ubRead;
 					}
 				}
 

--- a/tools/src/pak_tool.cpp
+++ b/tools/src/pak_tool.cpp
@@ -138,7 +138,12 @@ int main(int lArgCount, const char *pArgs[])
 					}
 				}
 
-				Entry.vData = std::vector(&vPackBuffer[0], &vPackBuffer[CompressedSize]);
+				if(CompressedSize < vFileContents.size() - 10) {
+					Entry.vData = std::vector(&vPackBuffer[0], &vPackBuffer[CompressedSize]);
+				}
+				else {
+					Entry.vData = vFileContents;
+				}
 			}
 			else {
 				Entry.vData = vFileContents;
@@ -160,9 +165,9 @@ int main(int lArgCount, const char *pArgs[])
 	std::uint16_t i = 0;
 	for(const auto &Entry: vEntries) {
 		fmt::print(
-			"Adding file {:4d}: '{}', offset: {}, size: {}, checksum: {:08X}...\n",
-			i++, Entry.ShortPath, ulNextFileOffs, Entry.vData.size(),
-			Entry.ulChecksum
+			"Adding file {:4d}: '{}', offset: {}, uncompressed: {}, size: {}, ratio: {:.2f}, checksum: {:08X}...\n",
+			i++, Entry.ShortPath, ulNextFileOffs, Entry.ulUncompressedSize,
+			Entry.vData.size(), float(Entry.vData.size()) / Entry.ulUncompressedSize * 100, Entry.ulChecksum
 		);
 
 		std::uint32_t ulChecksumBe = nEndian::toBig32(Entry.ulChecksum);

--- a/tools/src/pak_tool.cpp
+++ b/tools/src/pak_tool.cpp
@@ -128,7 +128,9 @@ int main(int lArgCount, const char *pArgs[])
 
 		auto CompressedSize = (std::uint32_t)compressPack(FileContents.data(), Entry.ulSize, vPackBuffer.data(), vPackBuffer.size());
 		vDecompressed.resize(Entry.ulSize);
-		compressUnpack(vPackBuffer.data(), CompressedSize, vDecompressed.data(), Entry.ulSize);
+		tCompressUnpackState UnpackState;
+		compressUnpackStateInit(&UnpackState, vPackBuffer.data(), CompressedSize, vDecompressed.data(), Entry.ulSize);
+		compressUnpackProcess(&UnpackState);
 		for(std::size_t i = 0; i < Entry.ulSize; ++i) {
 			if(vDecompressed[i] != FileContents[i]) {
 				nLog::error("mismatch at index {}", i);


### PR DESCRIPTION
<!--- Use this only if you've made significant changes to ACE's inner workings. -->

## Description

Adds support for custom lossless DPCM compression in audio files, as well as ability to compress entire pakfile with LZ77-like algorithm. Also adds diskFile caching, making reads/writes significantly faster. The compression is optional and when turned on, predictably slow things down a bit.

Also added some minor but breaking changes, like replacing diskFileOpen's std-like file access mode string param in favor of an enum, so that runtime cache checks for given mode can be done more efficiently and using unsupported modes like "x" won't be allowed.

Also adds `systemIsStartVolumeWritable()` which allows checking if the disk is write-protected. ACE now also prevents opening system requesters on file open failure, preventing game freezes in the process.

Also ptplayer sample-packs have now memory allocated per-sample, making them more granular and not requiring large chunks of Chip memory.

Closes #140 
Closes #243 

## Motivation and Context

This was required in order to fit the Aminer game into a single floppy disk. Previously, Battle Squadron 2 had problems with being too large for a floppy, so this should be useful for other future ACE productions.

## How Has This Been Tested?

Tested in recently-released Aminer, no problems so far.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [x] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
