### PR TITLE
Add `-nocs` option to skip OCS color checks

### DIFF
--- a/docs/tools/palette_conv.md
+++ b/docs/tools/palette_conv.md
@@ -44,6 +44,12 @@ If no output path is provided, it defaults to converting to `.gpl` format with s
 ACE is primarily designed for the Amiga OCS/ECS hardware, which uses 12-bit color (4 bits per RGB channel).
 When converting to ACE's native `.plt` format, the tool ensures that colors are compatible with OCS limitations, throwing errors when that's not the case.
 
+If you want to skip the OCS check and truncate colors to OCS limitations, pass `-nocs` as an extra option after the input path:
+
+```shell
+palette_conv palette.gpl palette.plt -nocs
+```
+
 When creating artwork for your game, you have to:
 
 - Use colors that work within Amiga's 12-bit color limitations (4 bits per channel), e.g. hex code `#112233` but not `#123456`

--- a/tools/src/palette_conv.cpp
+++ b/tools/src/palette_conv.cpp
@@ -9,15 +9,17 @@
 
 void printUsage(const std::string &szAppName) {
 	using fmt::print;
-	fmt::print("Usage:\n\t{} inPath.ext [outPath.ext]\n", szAppName);
+	fmt::print("Usage:\n\t{} inPath.ext [outPath.ext] [extraOpts]\n", szAppName);
 	print("\ninPath\t- path to supported input palette file\n");
 	print("outPath\t- path to output palette file\n");
 	print("ext\t- one of the following:\n");
-	print("\tgpl\tGIMP Palette\n");
+	print("\tgpl\tGIMP Palette (default)\n");
 	print("\tact\tAdobe Color Table\n");
 	print("\tpal\tProMotion palette\n");
-	print("\tplt\tACE palette (default)\n");
+	print("\tplt\tACE palette\n");
 	print("\tpng\tPalette preview\n");
+	print("extraOpts:\n");
+	print("\t-nocs\tDon't fail during plt output if colors aren't OCS exact\n");
 }
 
 int main(int lArgCount, const char *pArgs[])
@@ -34,10 +36,17 @@ int main(int lArgCount, const char *pArgs[])
 
 	// Optional args' default values
 	std::string szPathOut = nFs::removeExt(szPathIn) + ".gpl";
+	bool isForceOcs = true;
 
 	// Search for optional args
-	if(lArgCount - 1 > 1) {
-		szPathOut = pArgs[2];
+	for(int ArgIndex = 2; ArgIndex < lArgCount; ++ArgIndex) {
+		const char *const pArg = pArgs[ArgIndex];
+		if(pArg == std::string("-nocs")) {
+			isForceOcs = false;
+		}
+		else {
+			szPathOut = pArg;
+		}
 	}
 
 	// Load input palette
@@ -67,7 +76,7 @@ int main(int lArgCount, const char *pArgs[])
 			isOk = Palette.toPromotionPal(szPathOut);
 		}
 		else if(szExtOut == "plt") {
-			isOk = Palette.toPlt(szPathOut, true);
+			isOk = Palette.toPlt(szPathOut, isForceOcs);
 		}
 		else if(szExtOut == "png") {
 			auto ColorCount = Palette.m_vColors.size();


### PR DESCRIPTION
<!--- Use this only if you've made non-breaking improvements or bugfixes -->

## Description
Adds a new optional command line argument, `-nocs`, which skips the check that each color in the palette can be truncated to OCS limits (12-bit color) without loss of data.

## Checklist
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [x] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.
