### PR TITLE
Tilebuffer redraw optimizations

### DIFF
--- a/include/ace/managers/system.h
+++ b/include/ace/managers/system.h
@@ -94,6 +94,23 @@ UWORD systemGetVersion(void);
 
 UBYTE systemIsStartVolumeWritable(void);
 
+/**
+ * Disable caches on 680x0 CPUs. Previous cache control words
+ * are stored so they can later be restored with
+ * systemRestoreCpuCaches.
+ *
+ * @see systemRestoreCpuCaches
+ */
+void systemDisableCpuCaches();
+
+/**
+ * Restore cache control settings after a previous call to
+ * systemDisableCpuCaches.
+ *
+ * @see systemDisableCpuCaches
+ */
+void systemRestoreCpuCaches();
+
 //---------------------------------------------------------------------- GLOBALS
 
 extern struct GfxBase *GfxBase;

--- a/include/ace/managers/viewport/tilebuffer.h
+++ b/include/ace/managers/viewport/tilebuffer.h
@@ -195,19 +195,18 @@ void tileBufferReset(
 
 /**
  * Redraws tiles on whole screen.
- * Use for init or something like that, as it's slooooooooow.
- * Be sure to have display turned off or palette dimmed since even on double
- * buffering it will redraw both buffers.
+ * 
+ * This method is slower than redrawing only what's needed, but depending on
+ * how many tiles need to be redrawn every frame, it may be competitive.
+ * If you only use it for initialization, have display turned off or palette dimmed
+ * since it will redraw both buffers for optimal performance.
+ * 
+ * When a lot is going on (many BOBs), the code when used with interleaved
+ * tilebuffer and tilemap is pretty optimized, to the point that redraw of half a
+ * 4bpp low-res screen of 16x16 tiles is possible on an A500. That saves then having
+ * to undraw BOBs, and may thus be better und some circumstances.
  */
-void tileBufferRedrawAllNonInterleaved(tTileBufferManager *pManager);
-
-/**
- * Redraws tiles on whole screen.
- * Use for init or something like that, as it's slooooooooow.
- * Be sure to have display turned off or palette dimmed since even on double
- * buffering it will redraw both buffers.
- */
-void tileBufferRedrawAllInterleaved(tTileBufferManager *pManager);
+void tileBufferRedrawAll(tTileBufferManager *pManager);
 
 /**
  * Redraws selected tile, calls custom redraw callback

--- a/include/ace/managers/viewport/tilebuffer.h
+++ b/include/ace/managers/viewport/tilebuffer.h
@@ -199,7 +199,15 @@ void tileBufferReset(
  * Be sure to have display turned off or palette dimmed since even on double
  * buffering it will redraw both buffers.
  */
-void tileBufferRedrawAll(tTileBufferManager *pManager);
+void tileBufferRedrawAllNonInterleaved(tTileBufferManager *pManager);
+
+/**
+ * Redraws tiles on whole screen.
+ * Use for init or something like that, as it's slooooooooow.
+ * Be sure to have display turned off or palette dimmed since even on double
+ * buffering it will redraw both buffers.
+ */
+void tileBufferRedrawAllInterleaved(tTileBufferManager *pManager);
 
 /**
  * Redraws selected tile, calls custom redraw callback

--- a/include/ace/managers/viewport/tilebuffer.h
+++ b/include/ace/managers/viewport/tilebuffer.h
@@ -196,17 +196,27 @@ void tileBufferReset(
 /**
  * Redraws tiles on whole screen.
  * 
+ * Use for init or something like that, as it's slooooooooow.
+ * Be sure to have display turned off or palette dimmed since even on double
+ * buffering it will redraw both buffers.
+ * 
+ * If you want to only fully redraw the back buffer, use tileBufferRedrawBack.
+ *
+ * @see tileBufferRedrawBack
+ */
+void tileBufferRedrawAll(tTileBufferManager *pManager);
+
+/**
+ * Redraws the tiles on the entire backbuffer.
+ * 
  * This method is slower than redrawing only what's needed, but depending on
  * how many tiles need to be redrawn every frame, it may be competitive.
- * If you only use it for initialization, have display turned off or palette dimmed
- * since it will redraw both buffers for optimal performance.
- * 
  * When a lot is going on (many BOBs), the code when used with interleaved
  * tilebuffer and tilemap is pretty optimized, to the point that redraw of half a
  * 4bpp low-res screen of 16x16 tiles is possible on an A500. That saves then having
  * to undraw BOBs, and may thus be better und some circumstances.
  */
-void tileBufferRedrawAll(tTileBufferManager *pManager);
+void tileBufferRedrawBack(tTileBufferManager *pManager);
 
 /**
  * Redraws selected tile, calls custom redraw callback

--- a/include/ace/types.h
+++ b/include/ace/types.h
@@ -49,6 +49,7 @@ typedef int32_t LONG;
 #define REGARG(arg, reg) arg
 #define CHIP
 #define FAR
+#define ALWAYS_INLINE
 #define FN_HOTSPOT
 #define FN_COLDSPOT
 #define BITFIELD_STRUCT struct __attribute__((packed))
@@ -60,6 +61,7 @@ typedef int32_t LONG;
 #define REGARG(arg, reg) arg
 #define CHIP __attribute__((section(".MEMF_CHIP")))
 #define FAR
+#define ALWAYS_INLINE __attribute__((always_inline))
 #define FN_HOTSPOT __attribute__((hot))
 #define FN_COLDSPOT __attribute__((cold))
 #define BITFIELD_STRUCT struct
@@ -79,6 +81,7 @@ typedef int32_t LONG;
 #define REGARG(arg, reg) arg asm(reg)
 #define CHIP __attribute__((chip))
 #define FAR __far
+#define ALWAYS_INLINE __attribute__((always_inline))
 #define FN_HOTSPOT __attribute__((hot))
 #define FN_COLDSPOT __attribute__((cold))
 #define BITFIELD_STRUCT struct

--- a/include/ace/types.h
+++ b/include/ace/types.h
@@ -52,6 +52,8 @@ typedef int32_t LONG;
 #define ALWAYS_INLINE
 #define FN_HOTSPOT
 #define FN_COLDSPOT
+#define LIKELY(x) x
+#define UNLIKELY(x) x
 #define BITFIELD_STRUCT struct __attribute__((packed))
 #elif defined(BARTMAN_GCC)
 #define INTERRUPT
@@ -64,6 +66,8 @@ typedef int32_t LONG;
 #define ALWAYS_INLINE __attribute__((always_inline))
 #define FN_HOTSPOT __attribute__((hot))
 #define FN_COLDSPOT __attribute__((cold))
+#define LIKELY(x) __builtin_expect(!!(x), 1)
+#define UNLIKELY(x) __builtin_expect(!!(x), 0)
 #define BITFIELD_STRUCT struct
 #elif defined(__GNUC__) // Bebbo
 #if defined(CONFIG_SYSTEM_OS_FRIENDLY)
@@ -84,6 +88,8 @@ typedef int32_t LONG;
 #define ALWAYS_INLINE __attribute__((always_inline))
 #define FN_HOTSPOT __attribute__((hot))
 #define FN_COLDSPOT __attribute__((cold))
+#define LIKELY(x) __builtin_expect(!!(x), 1)
+#define UNLIKELY(x) __builtin_expect(!!(x), 0)
 #define BITFIELD_STRUCT struct
 #else
 #error "Compiler not supported!"

--- a/src/ace/managers/system.c
+++ b/src/ace/managers/system.c
@@ -1189,7 +1189,7 @@ void systemReleaseBlitterToOs(void) {
 }
 
 UBYTE systemBlitterIsUsed(void) {
-	return s_wSystemBlitterUses > 0;
+	return s_wSystemBlitterUses <= 0;
 }
 
 void systemSetKeyInputHandler(tKeyInputHandler cbKeyInputHandler) {

--- a/src/ace/managers/system.c
+++ b/src/ace/managers/system.c
@@ -59,8 +59,33 @@ typedef struct _tAceInterrupt {
 
 // Store VBR query code in .text so that it plays nice with instruction cache
 // TODO: move to .s file after vasm support gets merged into cmake
+// Instructions: movec vbr,d0; rte
 __attribute__((section("text")))
 static const UWORD s_pGetVbrCode[] = {0x4e7a, 0x0801, 0x4e73};
+
+// Get cache control register contents (020+).
+// Instructions: movec cacr,d0; rte
+__attribute__((section("text")))
+static const UWORD s_pGetCacr[] = {0x4e7a, 0x0002, 0x4e73};
+
+// Get processor configuration register contents (060+).
+// Instructions: movec pcr,d0; rte
+__attribute__((section("text")))
+static const UWORD s_pGetPcr[] = {0x4e7a, 0x0801, 0x4e73};
+
+// Move d0 into the cache control register
+// movec d0,cacr; rte
+__attribute__((section("text")))
+static const UWORD s_pSetCacr[] = {0x4e7b, 0x0002, 0x4e73};
+
+// Move d0 into the cache control register and flush caches
+// movec d0,cacr; cpusha ic+dc; rte
+__attribute__((section("text")))
+static const UWORD s_pSetCacr040[] = {0x4e7b, 0x0002, 0xf4f8, 0x4e73};
+
+// Move d0 into the processor configuration register
+__attribute__((section("text")))
+static const UWORD s_pSetPcr[] = {0x4e7b, 0x801, 0x4e73};
 
 // Saved regs
 static UWORD s_uwOsIntEna;
@@ -99,6 +124,14 @@ static tKeyInputHandler s_cbKeyInputHandler;
 // Manager logic vars
 static WORD s_wSystemUses;
 static WORD s_wSystemBlitterUses;
+
+typedef struct tCpuCacheFlags {
+    ULONG ulCacr;
+    ULONG ulPcr;
+    WORD wDisabledCount;
+} tCpuCacheFlags;
+
+static tCpuCacheFlags s_sCpuCacheFlags;
 
 struct GfxBase *GfxBase = 0;
 struct View *s_pOsView;
@@ -930,6 +963,30 @@ void systemCreate(void) {
 	// Disable system so that it gets backed up once, skip saving intena from systemUnuse()
 	s_wSystemUses = 0;
 	s_wSystemBlitterUses = 1;
+
+	// Query processor cache settings.
+	if (SysBase->AttnFlags & AFF_68020) {
+		s_sCpuCacheFlags.ulCacr = (ULONG)Supervisor((void *)s_pGetCacr);
+	} else {
+		s_sCpuCacheFlags.ulCacr = 0;
+	}
+	// Query PCR to check if superscalar dispatch is enabled (bit 0). Older Kickstarts may not
+	// support detecting the 68060, but in that case the Kickstart also won't enable it.
+	// If we ever do run into the problem that someone enables superscalar dispatch on KS1.3,
+	// we can adapt https://github.com/keirf/flashfloppy-autoswap/blob/master/shared/disable_caches.S
+	// (which itself is based on code from ross https://eab.abime.net/showpost.php?p=1303326&postcount=3)
+	// and execute the instructions to get the PCR under a trap handler that skips it.
+	if (SysBase->AttnFlags & AFF_68060) {
+		s_sCpuCacheFlags.ulPcr = (ULONG)Supervisor((void *)s_pGetPcr);
+	} else {
+		s_sCpuCacheFlags.ulPcr = 0;
+	}
+	s_sCpuCacheFlags.wDisabledCount = 0;
+	if (!s_sCpuCacheFlags.ulCacr && !s_sCpuCacheFlags.ulPcr) {
+		// no caches enabled, treat as always disabled
+		++s_sCpuCacheFlags.wDisabledCount;
+	}
+
 	systemOsDisable();
 	systemUse(); // Re-enable as little as needed
 
@@ -945,6 +1002,16 @@ void systemDestroy(void) {
 	while (!(g_pCustom->intreqr & INTF_VERTB)) continue;
 	g_pCustom->dmacon = 0x07FF;
 	g_pCustom->intreq = 0x7FFF;
+
+	if(s_sCpuCacheFlags.wDisabledCount != 0) {
+		if(s_sCpuCacheFlags.ulCacr == 0 && s_sCpuCacheFlags.ulPcr == 0) {
+			if(s_sCpuCacheFlags.wDisabledCount != 1) {
+				logWrite("ERR: unclosed/overclosed cpu cache count: %hd\n", s_sCpuCacheFlags.wDisabledCount - 1);
+			}
+		} else {
+			logWrite("ERR: unclosed/overclosed cpu cache count: %hd\n", s_sCpuCacheFlags.wDisabledCount);
+		}
+	}
 
 	// Start waking up OS
 	if(s_wSystemUses != 1) {
@@ -1298,4 +1365,52 @@ UBYTE systemIsStartVolumeWritable(void) {
 	systemGetBlitterFromOs();
 	systemUnuse();
 	return isWritable;
+}
+
+void systemDisableCpuCaches() {
+	++s_sCpuCacheFlags.wDisabledCount;
+	if (s_sCpuCacheFlags.wDisabledCount > 1) {
+		return;
+	}
+
+	register volatile ULONG cacheDisable __asm("d0");
+	if (UNLIKELY(s_sCpuCacheFlags.ulCacr & 0x80008000)) {
+		// on 68040+, bits 31 and 15 control if the caches are enabled,
+		// flushing is done via the CPUSHA instruction
+		cacheDisable = s_sCpuCacheFlags.ulCacr & ~(0x80008000);
+		Supervisor((void *)s_pSetCacr040);
+	} else if (UNLIKELY(s_sCpuCacheFlags.ulCacr & 0x101)) {
+		// on 68020+, bit 1 is the instruction cache, writing bit 3 as 1 flushes it
+		// on 68030+, bit 8 is the data cache, writing bit 11 as 1 flushes it
+		cacheDisable = 0x808;
+		Supervisor((void *)s_pSetCacr);
+	}
+	if (UNLIKELY(s_sCpuCacheFlags.ulPcr & 0x1)) {
+		// clear low bit, the superscalar dispatch bit
+		cacheDisable = s_sCpuCacheFlags.ulPcr & ~0x1;
+		Supervisor((void *)s_pSetPcr);
+	}
+}
+
+void systemRestoreCpuCaches() {
+	--s_sCpuCacheFlags.wDisabledCount;
+	if (s_sCpuCacheFlags.wDisabledCount > 0) {
+		return;
+	}
+#if defined(ACE_DEBUG)
+	if (s_sCpuCacheFlags.wDisabledCount < 0) {
+		logWrite("ERR: systemRestoreCpuCaches called more often than systemDisableCpuCaches\n");
+		s_sCpuCacheFlags.wDisabledCount = 0;
+	}
+#endif
+
+	register volatile ULONG cacheEnable __asm("d0");
+	if (s_sCpuCacheFlags.ulCacr) {
+		cacheEnable = s_sCpuCacheFlags.ulCacr;
+		Supervisor((void *)s_pSetCacr);
+	}
+	if (s_sCpuCacheFlags.ulPcr) {
+		cacheEnable = s_sCpuCacheFlags.ulPcr;
+		Supervisor((void *)s_pSetPcr);
+	}
 }

--- a/src/ace/managers/viewport/tilebuffer.c
+++ b/src/ace/managers/viewport/tilebuffer.c
@@ -465,6 +465,7 @@ void tileBufferProcess(tTileBufferManager *pManager) {
 				UWORD uwTileOffsX = (pState->pMarginX->wTilePos << ubTileShift);
 				// Redraw remaining tiles
 				UWORD uwBltsize = tileBufferSetupTileDraw(pManager);
+				UBYTE isInterleaved = !(uwBltsize & BLIT_WORDS_NON_INTERLEAVED_BIT);
 				UWORD uwTileCurr = pState->pMarginX->wTileCurr;
 				UWORD uwTileEnd = pState->pMarginX->wTileEnd;
 				UWORD uwMarginedHeight = pManager->uwMarginedHeight;
@@ -484,7 +485,7 @@ void tileBufferProcess(tTileBufferManager *pManager) {
 						pManager, pTileColumn, uwTileCurr,
 						uwBltsize, ulDstOffs, pDstPlane,
 						// do not set bltdpt, it was left at the right place by the previous blit
-						0, 1, !(uwBltsize & BLIT_WORDS_NON_INTERLEAVED_BIT)
+						0, 1, isInterleaved
 					);
 					++uwTileCurr;
 					uwTileOffsY += ubTileSize;
@@ -579,6 +580,7 @@ void tileBufferProcess(tTileBufferManager *pManager) {
 				UWORD uwTileOffsX = (pState->pMarginY->wTileCurr << ubTileShift);
 				// Redraw remaining tiles
 				UWORD uwBltsize = tileBufferSetupTileDraw(pManager);
+				UBYTE isInterleaved = !(uwBltsize & BLIT_WORDS_NON_INTERLEAVED_BIT);
 				UWORD uwTileCurr = pState->pMarginY->wTileCurr;
 				UWORD uwTileEnd = pState->pMarginY->wTileEnd;
 				UWORD uwTilePos = pState->pMarginY->wTilePos;
@@ -590,7 +592,7 @@ void tileBufferProcess(tTileBufferManager *pManager) {
 					tileBufferContinueTileDraw(
 						pManager, pTileData[uwTileCurr], uwTilePos,
 						uwBltsize, ulDstOffs, pDstPlane, 1, 1,
-						!(uwBltsize & BLIT_WORDS_NON_INTERLEAVED_BIT)
+						isInterleaved
 					);
 					++uwTileCurr;
 					ulDstOffs += uwDstOffsStep;

--- a/src/ace/managers/viewport/tilebuffer.c
+++ b/src/ace/managers/viewport/tilebuffer.c
@@ -714,7 +714,7 @@ static inline void tileBufferRedrawAllInternal(tTileBufferManager *pManager, UBY
 				0, 0, isInterleaved
 			);
 			if (!isInterleaved) {
-				ulDstOffs += uwDstBytesPerRow;
+				ulDstOffs += (uwDstBytesPerRow << ubTileShift);
 			}
 		}
 		ulDstOffs = uwDstXOffset;
@@ -731,7 +731,7 @@ static inline void tileBufferRedrawAllInternal(tTileBufferManager *pManager, UBY
 				0, 0, isInterleaved
 			);
 			if (!isInterleaved) {
-				ulDstOffs += uwDstBytesPerRow;
+				ulDstOffs += (uwDstBytesPerRow << ubTileShift);
 			}
 		}
 	}

--- a/src/ace/managers/viewport/tilebuffer.c
+++ b/src/ace/managers/viewport/tilebuffer.c
@@ -793,7 +793,9 @@ void tileBufferRedrawAll(tTileBufferManager *pManager) {
  * when we are executing tileBufferRedrawAllInternal, so the CPU is actually
  * blocked by the blitter and we can save the extra instructions for waiting.
  */
-CHIP
+#if !defined(ACE_DEBUG)
+CHIP // stepping into chipmem annotated functions is a bit wonky on bartman's vscode plugin
+#endif
 void tileBufferRedrawBack(tTileBufferManager *pManager) {
 	UBYTE ubSrcInterleaved = bitmapIsInterleaved(pManager->pTileSet);
 	UBYTE ubDstInterleaved = bitmapIsInterleaved(pManager->pScroll->pBack);

--- a/src/ace/managers/viewport/tilebuffer.c
+++ b/src/ace/managers/viewport/tilebuffer.c
@@ -373,7 +373,7 @@ static UWORD tileBufferSetupTileDraw(const tTileBufferManager *pManager) {
  * bitmaps, but it works for non-interleaved bitmaps, too, with
  * a slightly larger performance hit.
  */
-FN_HOTSPOT
+ALWAYS_INLINE
 static inline void tileBufferContinueTileDraw(
 	const tTileBufferManager *pManager, const tTileBufferTileIndex *pTileDataColumn,
 	UWORD uwTileY, UWORD uwBltsize, ULONG ulDstOffs, PLANEPTR pDstPlane, UBYTE ubSetDst,
@@ -650,6 +650,7 @@ void tileBufferProcess(tTileBufferManager *pManager) {
 
 // This is used below with ubNonInterleavedBlit either 0 or 1, so with the inlining this is
 // a poor man's function template specialization...
+ALWAYS_INLINE
 static inline void tileBufferRedrawAllInternal(tTileBufferManager *pManager, UBYTE ubNonInterleavedBlit) {
 	logBlockBegin("tileBufferRedrawAll(pManager: %p)", pManager);
 

--- a/src/ace/managers/viewport/tilebuffer.c
+++ b/src/ace/managers/viewport/tilebuffer.c
@@ -382,7 +382,7 @@ static UWORD tileBufferSetupTileDraw(const tTileBufferManager *pManager) {
 ALWAYS_INLINE
 static inline void tileBufferContinueTileDraw(
 	const tTileBufferManager *pManager, const tTileBufferTileIndex *pTileDataColumn,
-	UWORD uwTileY, UWORD uwBltsize, ULONG ulDstOffs, PLANEPTR pDstPlane, UBYTE ubSetDst,
+	UWORD uwTileY, UWORD uwBltsize, ULONG ulDstOffs, PLANEPTR pDstPlane, UBYTE isSetDst,
 	UBYTE isWaitForBlit, UBYTE isInterleaved
 ) {
 	tTileBufferTileIndex TileToDraw = pTileDataColumn[uwTileY];
@@ -393,9 +393,9 @@ static inline void tileBufferContinueTileDraw(
 		// this check folds away
 		UBYTE *pUbBltapt = pManager->pTileSetOffsets[TileToDraw];
 		UBYTE *pUbBltdpt;
-		if (ubSetDst) {
+		if (isSetDst) {
 			// this function should be inlined into the caller, where
-			// ubSetDst should be a *constant* argument, so this check
+			// isSetDst should be a *constant* argument, so this check
 			// folds away
 			pUbBltdpt = pDstPlane + ulDstOffs;
 		}
@@ -406,7 +406,7 @@ static inline void tileBufferContinueTileDraw(
 			blitWait(); // Don't modify registers when other blit is in progress
 		}
 		g_pCustom->bltapt = pUbBltapt;
-		if (ubSetDst) {
+		if (isSetDst) {
 			g_pCustom->bltdpt = pUbBltdpt;
 		}
 		g_pCustom->bltsize = uwBltsize;

--- a/src/ace/managers/viewport/tilebuffer.c
+++ b/src/ace/managers/viewport/tilebuffer.c
@@ -755,9 +755,6 @@ static inline void tileBufferRedrawAllInternal(tTileBufferManager *pManager, UBY
 			);
 		}
 	}
-
-	// Refresh bitplane pointers in scrollBuffer's copprtlist
-	scrollBufferProcess(pManager->pScroll);
 }
 
 void tileBufferRedrawAll(tTileBufferManager *pManager) {
@@ -792,7 +789,8 @@ void tileBufferRedrawAll(tTileBufferManager *pManager) {
 		*(pDst++) = *(pSrc++);
 	}
 
-	// Refresh bitplane pointers in scrollBuffer's copprtlist - 2nd time for dbl bfr
+	// Refresh bitplane pointers in scrollBuffer's copprtlist - 2x for dbl bfr
+	scrollBufferProcess(pManager->pScroll);
 	scrollBufferProcess(pManager->pScroll);
 
 	logBlockEnd("tileBufferRedrawAll()");

--- a/src/ace/managers/viewport/tilebuffer.c
+++ b/src/ace/managers/viewport/tilebuffer.c
@@ -484,7 +484,7 @@ void tileBufferProcess(tTileBufferManager *pManager) {
 						pManager, pTileColumn, uwTileCurr,
 						uwBltsize, ulDstOffs, pDstPlane,
 						// do not set bltdpt, it was left at the right place by the previous blit
-						0, 1, uwBltsize & BLIT_WORDS_NON_INTERLEAVED_BIT
+						0, 1, !(uwBltsize & BLIT_WORDS_NON_INTERLEAVED_BIT)
 					);
 					++uwTileCurr;
 					uwTileOffsY += ubTileSize;
@@ -590,7 +590,7 @@ void tileBufferProcess(tTileBufferManager *pManager) {
 					tileBufferContinueTileDraw(
 						pManager, pTileData[uwTileCurr], uwTilePos,
 						uwBltsize, ulDstOffs, pDstPlane, 1, 1,
-						uwBltsize & BLIT_WORDS_NON_INTERLEAVED_BIT
+						!(uwBltsize & BLIT_WORDS_NON_INTERLEAVED_BIT)
 					);
 					++uwTileCurr;
 					ulDstOffs += uwDstOffsStep;


### PR DESCRIPTION
This is as fast I seem to be able to get it for interleaved full redraws.

<img width="668" height="71" alt="image" src="https://github.com/user-attachments/assets/2e248a66-037c-42e4-8db1-600413bba7a6" />
<img width="728" height="168" alt="image" src="https://github.com/user-attachments/assets/e0d98b13-f02c-44f3-9fea-5317427a0068" />

