### PR TITLE
Support placing code and data in CHIP memory without gcc complaining

### DIFF
--- a/include/ace/types.h
+++ b/include/ace/types.h
@@ -48,6 +48,12 @@ typedef int32_t LONG;
 #define UNUSED_ARG __attribute__((unused))
 #define REGARG(arg, reg) arg
 #define CHIP
+// Data in chip memory. While on Amiga CHIP mem is all one region, GCC needs to tell apart executable from data, from zero-initialized data
+#define CHIP_DATA
+// Code in chip memory. While on Amiga CHIP mem is all one region, GCC needs to tell apart executable from data, from zero-initialized data
+#define CHIP_CODE
+// Zero-initialized data in chip memory. While on Amiga CHIP mem is all one region, GCC needs to tell apart executable from data, from zero-initialized data
+#define CHIP_BSS
 #define FAR
 #define ALWAYS_INLINE
 #define FN_HOTSPOT
@@ -62,6 +68,15 @@ typedef int32_t LONG;
 #define UNUSED_ARG __attribute__((unused))
 #define REGARG(arg, reg) arg
 #define CHIP __attribute__((section(".MEMF_CHIP")))
+// Data in chip memory. While on Amiga CHIP mem is all one region, GCC needs to tell apart executable from data, from zero-initialized data
+// The naming is like this because "ld" absorbs ".data.*" sections, and elf2hunk looks for sections ending in ".MEMF_CHIP" to put in chip memory
+#define CHIP_DATA __attribute__((section(".chipdata.MEMF_CHIP")))
+// Code in chip memory. While on Amiga CHIP mem is all one region, GCC needs to tell apart executable from data, from zero-initialized data
+// The naming is like this because "ld" absorbs ".text.*" sections, and elf2hunk looks for sections ending in ".MEMF_CHIP" to put in chip memory
+#define CHIP_CODE __attribute__((section(".chiptext.MEMF_CHIP")))
+// Zero-initialized data in chip memory. While on Amiga CHIP mem is all one region, GCC needs to tell apart executable from data, from zero-initialized data
+// The naming is like this because "ld" absorbs ".bss.*" sections, and elf2hunk looks for sections ending in ".MEMF_CHIP" to put in chip memory
+#define CHIP_BSS __attribute__((section(".chipbss.MEMF_CHIP")))
 #define FAR
 #define ALWAYS_INLINE __attribute__((always_inline))
 #define FN_HOTSPOT __attribute__((hot))
@@ -84,6 +99,9 @@ typedef int32_t LONG;
 #define UNUSED_ARG __attribute__((unused))
 #define REGARG(arg, reg) arg asm(reg)
 #define CHIP __attribute__((chip))
+#define CHIP_DATA __attribute__((chip))
+#define CHIP_CODE __attribute__((chip))
+#define CHIP_BSS __attribute__((chip))
 #define FAR __far
 #define ALWAYS_INLINE __attribute__((always_inline))
 #define FN_HOTSPOT __attribute__((hot))

--- a/src/ace/managers/viewport/tilebuffer.c
+++ b/src/ace/managers/viewport/tilebuffer.c
@@ -804,7 +804,7 @@ void tileBufferRedrawAll(tTileBufferManager *pManager) {
  * blocked by the blitter and we can save the extra instructions for waiting.
  */
 #if !defined(ACE_DEBUG) && defined(BARTMAN_GCC)
-CHIP // stepping into chipmem annotated functions is a bit wonky on bartman's vscode plugin
+CHIP_CODE // stepping into chipmem annotated functions is a bit wonky on bartman's vscode plugin
 #endif
 void tileBufferRedrawBack(tTileBufferManager *pManager) {
 	UBYTE ubSrcInterleaved = bitmapIsInterleaved(pManager->pTileSet);


### PR DESCRIPTION
## Description

Allow placing both some data and some code into chip memory. Even though on the amiga (through elf2hunk) this all just is CHIP mem, gcc needs to place it in an ELF file first, and that requires separate sections for executable, read/writable, and zero-initialized things. So if one uses chip, one should be explicit, or else get linker errors when more than one kind of section is needed.

## Checklist
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
