### PR TITLE
Fix font_conv docs inconsistency (-charFile param)

### DIFF
--- a/docs/tools/font_conv.md
+++ b/docs/tools/font_conv.md
@@ -25,7 +25,7 @@ Unless otherwise stated, you are free to convert between any of them.
 Extra options are:
 
 - `-chars` - Specifies characters to include in the font
-- `-charfile` - Use characters from a text file
+- `-charFile` - Use characters from a text file
 - `-size` - Set font size for rasterization (for TTF fonts)
 - `-out` - Specify output path
 - `-fc` - Set first character index (for ProMotion NG fonts)

--- a/tools/src/font_conv.cpp
+++ b/tools/src/font_conv.cpp
@@ -48,7 +48,7 @@ void printUsage(const std::string &szAppName) {
 	print("\t\t\t\tUse backslash (\\) to escape quote (\") char inside charset specifier\n");
 	print("\t\t\t\tDefault charset is: \"{}\"\n\n", s_szDefaultCharset);
 	// -charFile
-	print("\t-charfile \"file.txt\"\tInclude chars specified in file.txt.\n");
+	print("\t-charFile \"file.txt\"\tInclude chars specified in file.txt.\n");
 	print("\t\t\t\tNewline chars (\\r, \\n) and repeats are omitted.\n\n");
 	// -size
 	print("\t-size 8\t\t\tRasterize font using size of 8pt. Default: 20.\n\n");


### PR DESCRIPTION
This PR fixes inconsistency of `-charFile` case sensitivity in documentation.