### PR TITLE
Fix BPLCON2 when enabling KILLEHB for 6 bitplanes (AGA)

### DIFF
--- a/src/ace/utils/extview.c
+++ b/src/ace/utils/extview.c
@@ -261,8 +261,8 @@ void viewLoad(tView *pView) {
 				g_pCustom->bplcon0 |= BV(4);
 			}
 			if(pView->pFirstVPort->ubBpp == 6) {
-				/* KILLEHB: true 64 colors; |= preserves sprite/playfield priority. */
-				g_pCustom->bplcon2 |= BV(9);
+				/* KILLEHB + Kickstart-style PF/sprite priority (BV(2)|BV(5) == 0x24) */
+				g_pCustom->bplcon2 = (UWORD)(BV(2) | BV(5) | BV(9));
 			}
 		}
 		else {

--- a/src/ace/utils/extview.c
+++ b/src/ace/utils/extview.c
@@ -261,7 +261,8 @@ void viewLoad(tView *pView) {
 				g_pCustom->bplcon0 |= BV(4);
 			}
 			if(pView->pFirstVPort->ubBpp == 6) {
-				g_pCustom->bplcon2 = BV(9); // KILLEHB for 64 colors on AGA
+				/* KILLEHB: true 64 colors; |= preserves sprite/playfield priority. */
+				g_pCustom->bplcon2 |= BV(9);
 			}
 		}
 		else {


### PR DESCRIPTION
**Problem:**
For 6bpp displays, viewLoad() set bplcon2 = BV(9) (KILLEHB). That overwrote the rest of the register and cleared sprite/playfield priority bits, so hardware sprites could end up behind the playfield.

**Change:**
 Use bplcon2 = (BV(2) | BV(5) | BV(9)) so KILLEHB is set with the kickstart default values