### PR TITLE
Fix mini_std fwrite/fread performance issue

### DIFF
--- a/src/ace/utils/disk_file.c
+++ b/src/ace/utils/disk_file.c
@@ -105,7 +105,7 @@ DISKFILE_PRIVATE ULONG diskFileRead(void *pData, void *pDest, ULONG ulSize) {
 		if(!pDiskFileData->isUninterrupted) {
 			fileAccessEnable();
 		}
-		ULONG ulReadPartSize = fread(pDestBytes, ulSize, 1, pDiskFileData->pFileHandle);
+		ULONG ulReadPartSize = fread(pDestBytes, 1, ulSize, pDiskFileData->pFileHandle);
 		pDestBytes += ulReadPartSize;
 		ulReadCount += ulReadPartSize;
 		ulSize -= ulReadPartSize;

--- a/src/mini_std/stdio_file.c
+++ b/src/mini_std/stdio_file.c
@@ -36,19 +36,20 @@ FILE *fopen(const char *restrict szFileName, const char *restrict szMode) {
 
 size_t fread(void *restrict pBuffer, size_t Size, size_t Count, FILE *restrict pStream) {
 	// http://amigadev.elowar.com/read/ADCD_2.1/Includes_and_Autodocs_3._guide/node01A0.html
-	LONG lBytesRead;
 	if(Size == 0 || Count == 0) return 0;
-	lBytesRead = Read((BPTR)pStream, pBuffer, Size * Count);
+	if(Count > SIZE_MAX / Size) return 0;
+	// Read() returns -1 on error (IoErr() has details)
+	LONG lBytesRead = Read((BPTR)pStream, pBuffer, Size * Count);
 	if(lBytesRead <= 0) return 0;
 	return (size_t)lBytesRead / Size;
 }
 
 size_t fwrite(const void *restrict pBuffer, size_t Size, size_t Count, FILE *restrict pStream) {
 	// http://amigadev.elowar.com/read/ADCD_2.1/Includes_and_Autodocs_3._guide/node01D1.html
-	LONG lBytesWritten;
 	if(Size == 0 || Count == 0) return 0;
-	lBytesWritten = Write((BPTR)pStream, pBuffer, Size * Count);
-	if(lBytesWritten <= 0) return 0;
+	if(Count > SIZE_MAX / Size) return 0;
+	LONG lBytesWritten = Write((BPTR)pStream, (void *)pBuffer, Size * Count);
+	if(lBytesWritten < 0) return 0;
 	return (size_t)lBytesWritten / Size;
 }
 

--- a/src/mini_std/stdio_file.c
+++ b/src/mini_std/stdio_file.c
@@ -37,20 +37,40 @@ FILE *fopen(const char *restrict szFileName, const char *restrict szMode) {
 
 size_t fread(void *restrict pBuffer, size_t Size, size_t Count, FILE *restrict pStream) {
 	// http://amigadev.elowar.com/read/ADCD_2.1/Includes_and_Autodocs_3._guide/node01A0.html
-	if(Size == 0 || Count == 0) return 0;
-	if(Count > SIZE_MAX / Size) return 0;
+	if(Size == 0 || Count == 0) {
+		return 0;
+	}
+
+	if(Count > SIZE_MAX / Size) {
+		return 0;
+	}
+
 	// Read() returns -1 on error (IoErr() has details)
 	LONG lBytesRead = Read((BPTR)pStream, pBuffer, Size * Count);
-	if(lBytesRead <= 0) return 0;
+
+	if(lBytesRead <= 0) {
+		return 0;
+	}
+
 	return (size_t)lBytesRead / Size;
 }
 
 size_t fwrite(const void *restrict pBuffer, size_t Size, size_t Count, FILE *restrict pStream) {
 	// http://amigadev.elowar.com/read/ADCD_2.1/Includes_and_Autodocs_3._guide/node01D1.html
-	if(Size == 0 || Count == 0) return 0;
-	if(Count > SIZE_MAX / Size) return 0;
+	if(Size == 0 || Count == 0) {
+		return 0;
+	}
+
+	if(Count > SIZE_MAX / Size) {
+		return 0;
+	}
+
 	LONG lBytesWritten = Write((BPTR)pStream, (void *)pBuffer, Size * Count);
-	if(lBytesWritten < 0) return 0;
+
+	if(lBytesWritten < 0) {
+		return 0;
+	}
+
 	return (size_t)lBytesWritten / Size;
 }
 

--- a/src/mini_std/stdio_file.c
+++ b/src/mini_std/stdio_file.c
@@ -1,6 +1,7 @@
 #include <stdio.h>
 #include <ace/types.h>
 #include <proto/dos.h>
+#include <stdint.h>
 
 // Some things are implemented from scratch, some are based on:
 // https://github.com/deplinenoise/amiga-sdk/blob/master/netinclude/stdio.h

--- a/src/mini_std/stdio_file.c
+++ b/src/mini_std/stdio_file.c
@@ -36,25 +36,20 @@ FILE *fopen(const char *restrict szFileName, const char *restrict szMode) {
 
 size_t fread(void *restrict pBuffer, size_t Size, size_t Count, FILE *restrict pStream) {
 	// http://amigadev.elowar.com/read/ADCD_2.1/Includes_and_Autodocs_3._guide/node01A0.html
-	unsigned char *pByteBuffer = (unsigned char *)pBuffer;
-	size_t BytesRead = 0;
-	while(Count--) {
-		// FIXME: handle 0/negative vals
-		BytesRead += Read((BPTR)pStream, pByteBuffer, Size);
-		pByteBuffer += Size;
-	}
-	return BytesRead;
+	LONG lBytesRead;
+	if(Size == 0 || Count == 0) return 0;
+	lBytesRead = Read((BPTR)pStream, pBuffer, Size * Count);
+	if(lBytesRead <= 0) return 0;
+	return (size_t)lBytesRead / Size;
 }
 
 size_t fwrite(const void *restrict pBuffer, size_t Size, size_t Count, FILE *restrict pStream) {
 	// http://amigadev.elowar.com/read/ADCD_2.1/Includes_and_Autodocs_3._guide/node01D1.html
-	unsigned char *pByteBuffer = (unsigned char *)pBuffer;
-	size_t BytesWritten = 0;
-	while(Count--) {
-		BytesWritten += Write((BPTR)pStream, pByteBuffer, Size);
-		pByteBuffer += Size;
-	}
-	return BytesWritten;
+	LONG lBytesWritten;
+	if(Size == 0 || Count == 0) return 0;
+	lBytesWritten = Write((BPTR)pStream, pBuffer, Size * Count);
+	if(lBytesWritten <= 0) return 0;
+	return (size_t)lBytesWritten / Size;
 }
 
 int fclose(FILE *pStream) {


### PR DESCRIPTION
`fread` and `fwrite` in `mini_std/stdio_file.c` looped `Count` times calling `Read(Size)` / `Write(Size)`. This made `disk_file.c`'s direct read path (fread(buf, ulSize, 1, f)) issue one Read(1) per byte killing load times.

Fixed both to do a single `Read(Size * Count) / Write(Size * Count)` call, matching standard C return semantics (`bytesRead / Size`).

Also swapped `disk_file.c` line 108 to `fread(pDestBytes, 1, ulSize, ...)` so the return value correctly reflects bytes read.

Tested with Bartman toolchain. Please verify with bebbo to make sure nothing breaks there.