### PR TITLE
Fix scroller - 6BPP & 7BPP, fix HiRes

### DIFF
--- a/cmake/ace_config.cmake
+++ b/cmake/ace_config.cmake
@@ -13,7 +13,7 @@ set(ACE_TILEBUFFER_TILE_TYPE UBYTE CACHE STRING "Tilebuffer: Specify type used f
 set(ACE_SCROLLBUFFER_POT_BITMAP_HEIGHT ON CACHE BOOL "Scroll/tilebuffer: Round up the frame buffer height to power of two. More memory usage but faster calculations.")
 set(ACE_SCROLLBUFFER_ENABLE_SCROLL_X ON CACHE BOOL "Scroll/tilebuffer: Enables scroll in X direction.")
 set(ACE_SCROLLBUFFER_ENABLE_SCROLL_Y ON CACHE BOOL "Scroll/tilebuffer: Enables scroll in Y direction.")
-set(ACE_SCROLLBUFFER_X_MARGIN_SIZE 1 CACHE STRING "Scroll/tilebuffer: Number of tiles comprising into offscreen margins in X direction. Bigger allows drawing in bigger objects than tile size.")
+set(ACE_SCROLLBUFFER_X_MARGIN_SIZE 4 CACHE STRING "Scroll/tilebuffer: Number of tiles comprising into offscreen margins in X direction. Bigger allows drawing in bigger objects than tile size.")
 set(ACE_SCROLLBUFFER_Y_MARGIN_SIZE 1 CACHE STRING "Scroll/tilebuffer: Number of tiles comprising into offscreen margins in X direction. Bigger allows drawing in bigger objects than tile size.")
 set(ACE_FILE_USE_ONLY_DISK OFF CACHE BOOL "If enabled, only diskFile functions will be available for file access.")
 

--- a/cmake/ace_config.cmake
+++ b/cmake/ace_config.cmake
@@ -13,7 +13,7 @@ set(ACE_TILEBUFFER_TILE_TYPE UBYTE CACHE STRING "Tilebuffer: Specify type used f
 set(ACE_SCROLLBUFFER_POT_BITMAP_HEIGHT ON CACHE BOOL "Scroll/tilebuffer: Round up the frame buffer height to power of two. More memory usage but faster calculations.")
 set(ACE_SCROLLBUFFER_ENABLE_SCROLL_X ON CACHE BOOL "Scroll/tilebuffer: Enables scroll in X direction.")
 set(ACE_SCROLLBUFFER_ENABLE_SCROLL_Y ON CACHE BOOL "Scroll/tilebuffer: Enables scroll in Y direction.")
-set(ACE_SCROLLBUFFER_X_MARGIN_SIZE 4 CACHE STRING "Scroll/tilebuffer: Number of tiles comprising into offscreen margins in X direction. Bigger allows drawing in bigger objects than tile size.")
+set(ACE_SCROLLBUFFER_X_MARGIN_SIZE 1 CACHE STRING "Scroll/tilebuffer: Number of tiles comprising into offscreen margins in X direction. Bigger allows drawing in bigger objects than tile size.")
 set(ACE_SCROLLBUFFER_Y_MARGIN_SIZE 1 CACHE STRING "Scroll/tilebuffer: Number of tiles comprising into offscreen margins in X direction. Bigger allows drawing in bigger objects than tile size.")
 set(ACE_FILE_USE_ONLY_DISK OFF CACHE BOOL "If enabled, only diskFile functions will be available for file access.")
 

--- a/include/ace/utils/fetchmode.h
+++ b/include/ace/utils/fetchmode.h
@@ -24,7 +24,7 @@ static inline UWORD fetchModeGetDDfStep(const tVPort *pVPort) {
 		case 2:
 			return ((uwWidth / 32) - 1) * 16;
 		case 3:
-			return ((uwWidth / 16) - 1) * 6;
+			return ((uwWidth / 64) - 1) * 32;
 		case 0:
 		default:
 			return ((uwWidth / 16) - 1) * 8;

--- a/include/ace/utils/fetchmode.h
+++ b/include/ace/utils/fetchmode.h
@@ -45,12 +45,8 @@ static inline UWORD fetchModeGetDDfStop(const tVPort *pVPort) {
 	return fetchModeGetDDfStrt(pVPort) + fetchModeGetDDfStep(pVPort);
 }
 
-static inline UWORD fetchModeGetCopFetchDoneWaitX(const tVPort *pVPort) {
-	return fetchModeGetDDfStop(pVPort) + (pVPort->ubBpp << 1) + 2;
-}
-
 static inline UWORD fetchModeGetCopWaitX(const tVPort *pVPort) {
-	UWORD uwWaitAfterFetch = fetchModeGetCopFetchDoneWaitX(pVPort);
+	UWORD uwWaitAfterFetch = fetchModeGetDDfStop(pVPort) + (pVPort->ubBpp << 1) + 2;
 	UWORD uwLatestSafeWait = s_pCopperWaitXByBitplanes[pVPort->ubBpp];
 	return MIN(uwWaitAfterFetch, uwLatestSafeWait);
 }

--- a/include/ace/utils/fetchmode.h
+++ b/include/ace/utils/fetchmode.h
@@ -45,8 +45,12 @@ static inline UWORD fetchModeGetDDfStop(const tVPort *pVPort) {
 	return fetchModeGetDDfStrt(pVPort) + fetchModeGetDDfStep(pVPort);
 }
 
+static inline UWORD fetchModeGetCopFetchDoneWaitX(const tVPort *pVPort) {
+	return fetchModeGetDDfStop(pVPort) + (pVPort->ubBpp << 1) + 2;
+}
+
 static inline UWORD fetchModeGetCopWaitX(const tVPort *pVPort) {
-	UWORD uwWaitAfterFetch = fetchModeGetDDfStop(pVPort) + (pVPort->ubBpp << 1) + 2;
+	UWORD uwWaitAfterFetch = fetchModeGetCopFetchDoneWaitX(pVPort);
 	UWORD uwLatestSafeWait = s_pCopperWaitXByBitplanes[pVPort->ubBpp];
 	return MIN(uwWaitAfterFetch, uwLatestSafeWait);
 }

--- a/include/ace/utils/fetchmode.h
+++ b/include/ace/utils/fetchmode.h
@@ -6,6 +6,7 @@
 #define _ACE_UTILS_FETCHMODE_H_
 
 #include <ace/types.h>
+#include <ace/generic/screen.h>
 #include <ace/utils/extview.h>
 
 static inline UBYTE fetchModeGetBitplaneFmode(const tVPort *pVPort) {
@@ -50,8 +51,7 @@ static inline UWORD fetchModeGetCopWaitX(const tVPort *pVPort) {
 		return uwDDfStop + (uwFetchClocks << 1) + 2;
 	}
 
-	static const UWORD pCopperWaitXByBitplanes[9] = {0x00, 0xDC, 0xDC, 0xDC, 0xDC, 0xDC, 0xD9, 0xC6, 0xA0};
-	return pCopperWaitXByBitplanes[pVPort->ubBpp];
+	return s_pCopperWaitXByBitplanes[pVPort->ubBpp];
 }
 
 static inline UWORD fetchModeGetScrollPrefetchBytes(const tVPort *pVPort) {

--- a/include/ace/utils/fetchmode.h
+++ b/include/ace/utils/fetchmode.h
@@ -34,6 +34,7 @@ static inline UWORD fetchModeGetDDfStep(const tVPort *pVPort) {
 }
 
 static inline UWORD fetchModeGetDDfStrt(const tVPort *pVPort) {
+	// http://amigadev.elowar.com/read/ADCD_2.1/Hardware_Manual_guide/node0085.html
 	UWORD uwDDfStrt = (pVPort->pView->ubPosX + 15) / 2 - 16;
 	if(pVPort->eFlags & VP_FLAG_HIRES) {
 		uwDDfStrt += 4;
@@ -42,6 +43,7 @@ static inline UWORD fetchModeGetDDfStrt(const tVPort *pVPort) {
 }
 
 static inline UWORD fetchModeGetDDfStop(const tVPort *pVPort) {
+	// http://amigadev.elowar.com/read/ADCD_2.1/Hardware_Manual_guide/node0085.html
 	return fetchModeGetDDfStrt(pVPort) + fetchModeGetDDfStep(pVPort);
 }
 

--- a/include/ace/utils/fetchmode.h
+++ b/include/ace/utils/fetchmode.h
@@ -6,6 +6,7 @@
 #define _ACE_UTILS_FETCHMODE_H_
 
 #include <ace/types.h>
+#include <ace/macros.h>
 #include <ace/generic/screen.h>
 #include <ace/utils/extview.h>
 
@@ -45,13 +46,9 @@ static inline UWORD fetchModeGetDDfStop(const tVPort *pVPort) {
 }
 
 static inline UWORD fetchModeGetCopWaitX(const tVPort *pVPort) {
-	if (fetchModeGetBitplaneFmode(pVPort) == 3) {
-		UWORD uwDDfStop = fetchModeGetDDfStop(pVPort);
-		UWORD uwFetchClocks = pVPort->ubBpp;
-		return uwDDfStop + (uwFetchClocks << 1) + 2;
-	}
-
-	return s_pCopperWaitXByBitplanes[pVPort->ubBpp];
+	UWORD uwWaitAfterFetch = fetchModeGetDDfStop(pVPort) + (pVPort->ubBpp << 1) + 2;
+	UWORD uwLatestSafeWait = s_pCopperWaitXByBitplanes[pVPort->ubBpp];
+	return MIN(uwWaitAfterFetch, uwLatestSafeWait);
 }
 
 static inline UWORD fetchModeGetScrollPrefetchBytes(const tVPort *pVPort) {

--- a/include/ace/utils/fetchmode.h
+++ b/include/ace/utils/fetchmode.h
@@ -73,7 +73,9 @@ static inline UWORD fetchModeGetScrollDDfStartAdjust(const tVPort *pVPort) {
 		case 2:
 			return 16;
 		case 3:
-			return 24;
+			// One full 64-bit fetch block = 64 px = 32 color clocks, matching
+			// the 8-byte (4-word) prefetch that the modulo compensates for.
+			return 32;
 		case 0:
 		default:
 			return 8;
@@ -93,21 +95,6 @@ static inline void fetchModeApplyXScrollCopper(
 	*pModulo -= fetchModeGetScrollPrefetchBytes(pVPort);
 }
 
-static inline void fetchModeApplyScrollBufferXScrollCopper(
-	const tVPort *pVPort, UWORD *pDDfStrt, UWORD *pModulo
-) {
-	UWORD uwDDfStartAdjust = fetchModeGetScrollDDfStartAdjust(pVPort);
-
-	// Scrollbuffer uses a circular/corkscrew bitmap layout. FMODE 3 still
-	// needs the wider fetch modulo, but starting one extra fetch block earlier
-	// causes a 64 px ghost after the vertical wrap.
-	if(fetchModeGetBitplaneFmode(pVPort) == 3) {
-		uwDDfStartAdjust = 16;
-	}
-	*pDDfStrt -= uwDDfStartAdjust;
-	*pModulo -= fetchModeGetScrollPrefetchBytes(pVPort);
-}
-
 static inline LONG fetchModeGetInitialBplOffset(const tVPort *pVPort) {
 	if(pVPort->eFlags & VP_FLAG_HIRES) {
 		return -4;
@@ -117,31 +104,49 @@ static inline LONG fetchModeGetInitialBplOffset(const tVPort *pVPort) {
 }
 
 static inline UWORD fetchModeCalcBplShift(const tVPort *pVPort, UWORD uwScrollX) {
-	UWORD uwShift = (16 - (uwScrollX & 0xF)) & 0xF;
-
 	if(pVPort->eFlags & VP_FLAG_HIRES) {
-		uwShift >>= 1; // Usable scroll values are 0..7, shifts 2 pixels per value
+		UWORD uwShift = ((16 - (uwScrollX & 0xF)) & 0xF) >> 1; // 0..7, 2 px/value
+		return (uwShift << 4) | uwShift;
 	}
 
-	return (uwShift << 4) | uwShift;
+	// AGA wide fetch needs scroll over the whole fetch block (16/32/64 px), not
+	// just 16 px. The delay therefore spans 0..block-1 lo-res pixels and must be
+	// encoded into the extended BPLCON1 scroll bits (8 bits per playfield):
+	//   lo-res bits 0-3 -> PF1H2-H5 (bits 0-3) / PF2H2-H5 (bits 4-7)
+	//   lo-res bit  4   -> PF1H6 (bit 10) / PF2H6 (bit 14)  (16 px)
+	//   lo-res bit  5   -> PF1H7 (bit 11) / PF2H7 (bit 15)  (32 px)
+	UWORD uwBlock = fetchModeGetScrollPrefetchBytes(pVPort) << 3; // 16 / 32 / 64
+	UWORD uwDelay = (uwBlock - (uwScrollX & (uwBlock - 1))) & (uwBlock - 1);
+
+	UWORD uwLow = uwDelay & 0x0F;
+	UWORD uwBplcon1 = (uwLow << 4) | uwLow;
+	if(uwDelay & 0x10) {
+		uwBplcon1 |= (1 << 14) | (1 << 10);
+	}
+	if(uwDelay & 0x20) {
+		uwBplcon1 |= (1 << 15) | (1 << 11);
+	}
+	return uwBplcon1;
 }
 
 static inline LONG fetchModeCalcBplOffsetX(const tVPort *pVPort, UWORD uwScrollX) {
-	LONG lBplAddX = (((LONG)uwScrollX - 1) >> 4) << 1;
-
 	if(pVPort->eFlags & VP_FLAG_HIRES) {
-		return lBplAddX - 2;
+		return ((((LONG)uwScrollX - 1) >> 4) << 1) - 2;
 	}
 
+	// AGA wide fetch: the bitplane pointer must advance in whole fetch blocks
+	// (word/long/quad aligned). A 2-byte step in 32/64-bit fetch gets its low
+	// address bits truncated by the hardware -> "cut" picture every block.
+	// At uwScrollX == 0 this yields -block/8 bytes, i.e. the one-block prefetch.
 	switch(fetchModeGetBitplaneFmode(pVPort)) {
 		case 1:
 		case 2:
-			return lBplAddX - 2;
+			return (((LONG)uwScrollX - 1) >> 5) << 2; // 32 px block, 4-byte step
 		case 3:
-			return lBplAddX + 2;
+			return (((LONG)uwScrollX - 1) >> 6) << 3; // 64 px block, 8-byte step
 		case 0:
 		default:
-			return lBplAddX;
+			return (((LONG)uwScrollX - 1) >> 4) << 1; // 16 px block, 2-byte step
 	}
 }
 

--- a/include/ace/utils/fetchmode.h
+++ b/include/ace/utils/fetchmode.h
@@ -19,45 +19,65 @@ static inline UBYTE fetchModeGetBitplaneFmode(const tVPort *pVPort) {
 
 static inline UWORD fetchModeGetDDfStep(const tVPort *pVPort) {
 	UWORD uwWidth = pVPort->pView->uwWidth;
-	UBYTE ubBitplaneFmode = fetchModeGetBitplaneFmode(pVPort);
+	switch(fetchModeGetBitplaneFmode(pVPort)) {
+		case 1:
+		case 2:
+			return ((uwWidth / 32) - 1) * 16;
+		case 3:
+			return ((uwWidth / 16) - 1) * 6;
+		case 0:
+		default:
+			return ((uwWidth / 16) - 1) * 8;
+	}
+}
 
-	if(ubBitplaneFmode == 1 || ubBitplaneFmode == 2) {
-		return ((uwWidth / 32) - 1) * 16;
+static inline UWORD fetchModeGetDDfStrt(const tVPort *pVPort) {
+	UWORD uwDDfStrt = (pVPort->pView->ubPosX + 15) / 2 - 16;
+	if(pVPort->eFlags & VP_FLAG_HIRES) {
+		uwDDfStrt += 4;
+	}
+	return uwDDfStrt;
+}
+
+static inline UWORD fetchModeGetDDfStop(const tVPort *pVPort) {
+	return fetchModeGetDDfStrt(pVPort) + fetchModeGetDDfStep(pVPort);
+}
+
+static inline UWORD fetchModeGetCopWaitX(const tVPort *pVPort) {
+	if (fetchModeGetBitplaneFmode(pVPort) == 3) {
+		UWORD uwDDfStop = fetchModeGetDDfStop(pVPort);
+		UWORD uwFetchClocks = pVPort->ubBpp;
+		return uwDDfStop + (uwFetchClocks << 1) + 2;
 	}
 
-	if(ubBitplaneFmode == 3) {
-		return ((uwWidth / 16) - 1) * 6;
-	}
-
-	return ((uwWidth / 16) - 1) * 8;
+	static const UWORD pCopperWaitXByBitplanes[9] = {0x00, 0xDC, 0xDC, 0xDC, 0xDC, 0xDC, 0xD9, 0xC6, 0xA0};
+	return pCopperWaitXByBitplanes[pVPort->ubBpp];
 }
 
 static inline UWORD fetchModeGetScrollPrefetchBytes(const tVPort *pVPort) {
-	UBYTE ubBitplaneFmode = fetchModeGetBitplaneFmode(pVPort);
-
-	if(ubBitplaneFmode == 1 || ubBitplaneFmode == 2) {
-		return 4;
+	switch(fetchModeGetBitplaneFmode(pVPort)) {
+		case 1:
+		case 2:
+			return 4;
+		case 3:
+			return 8;
+		case 0:
+		default:
+			return 2;
 	}
-
-	if(ubBitplaneFmode == 3) {
-		return 8;
-	}
-
-	return 2;
 }
 
 static inline UWORD fetchModeGetScrollDDfStartAdjust(const tVPort *pVPort) {
-	UBYTE ubBitplaneFmode = fetchModeGetBitplaneFmode(pVPort);
-
-	if(ubBitplaneFmode == 1 || ubBitplaneFmode == 2) {
-		return 16;
+	switch(fetchModeGetBitplaneFmode(pVPort)) {
+		case 1:
+		case 2:
+			return 16;
+		case 3:
+			return 24;
+		case 0:
+		default:
+			return 8;
 	}
-
-	if(ubBitplaneFmode == 3) {
-		return 24;
-	}
-
-	return 8;
 }
 
 static inline void fetchModeApplyXScrollCopper(
@@ -108,17 +128,21 @@ static inline UWORD fetchModeCalcBplShift(const tVPort *pVPort, UWORD uwScrollX)
 
 static inline LONG fetchModeCalcBplOffsetX(const tVPort *pVPort, UWORD uwScrollX) {
 	LONG lBplAddX = (((LONG)uwScrollX - 1) >> 4) << 1;
-	UBYTE ubBitplaneFmode = fetchModeGetBitplaneFmode(pVPort);
 
-	if((pVPort->eFlags & VP_FLAG_HIRES) || ubBitplaneFmode == 1 || ubBitplaneFmode == 2) {
+	if(pVPort->eFlags & VP_FLAG_HIRES) {
 		return lBplAddX - 2;
 	}
 
-	if(ubBitplaneFmode == 3) {
-		return lBplAddX + 2;
+	switch(fetchModeGetBitplaneFmode(pVPort)) {
+		case 1:
+		case 2:
+			return lBplAddX - 2;
+		case 3:
+			return lBplAddX + 2;
+		case 0:
+		default:
+			return lBplAddX;
 	}
-
-	return lBplAddX;
 }
 
 #endif // _ACE_UTILS_FETCHMODE_H_

--- a/src/ace/managers/viewport/scrollbuffer.c
+++ b/src/ace/managers/viewport/scrollbuffer.c
@@ -20,6 +20,15 @@ static UWORD nearestPowerOf2(UWORD uwVal) {
 	return uwVal;
 }
 
+static UWORD scrollBufferAlignWidth(const tVPort *pVPort, UWORD uwWidth) {
+	// AGA wide fetch requires each bitplane row (hence BytesPerRow) to be a
+	// multiple of the fetch width. Otherwise Planes[i] + BytesPerRow * scrollY
+	// drifts out of fetch alignment and the bitplanes skew vertically (most
+	// visible in FMODE 3). Rounding up only enlarges the offscreen margin.
+	UWORD uwBlockPx = fetchModeGetScrollPrefetchBytes(pVPort) << 3; // 16 / 32 / 64
+	return ((uwWidth + uwBlockPx - 1) / uwBlockPx) * uwBlockPx;
+}
+
 tScrollBufferManager *scrollBufferCreate(void *pTags, ...) {
 	logBlockBegin("scrollBufferCreate(pTags: %p, ...)", pTags);
 
@@ -363,7 +372,10 @@ void scrollBufferGetBitmapDimensions(
 #if defined(ACE_SCROLLBUFFER_POT_BITMAP_HEIGHT)
 	uwBmAvailHeight = nearestPowerOf2(uwBmAvailHeight);
 #endif
-	*pWidth = uwVpWidth + ubMarginWidth * 2 * (ACE_SCROLLBUFFER_X_MARGIN_SIZE + SCROLLBUFFER_X_DRAW_MARGIN_SIZE);
+	*pWidth = scrollBufferAlignWidth(
+		pVPort,
+		uwVpWidth + ubMarginWidth * 2 * (ACE_SCROLLBUFFER_X_MARGIN_SIZE + SCROLLBUFFER_X_DRAW_MARGIN_SIZE)
+	);
 	*pHeight = uwBmAvailHeight + blockCountCeil(uwBoundWidth, uwVpWidth) - 1;
 }
 
@@ -393,7 +405,10 @@ void scrollBufferReset(
 
 	scrollBufferDestroyOwnedBitmaps(pManager);
 
-	UWORD uwCalcWidth = uwVpWidth + ubMarginWidth * 2 * (ACE_SCROLLBUFFER_X_MARGIN_SIZE + SCROLLBUFFER_X_DRAW_MARGIN_SIZE);
+	UWORD uwCalcWidth = scrollBufferAlignWidth(
+		pManager->sCommon.pVPort,
+		uwVpWidth + ubMarginWidth * 2 * (ACE_SCROLLBUFFER_X_MARGIN_SIZE + SCROLLBUFFER_X_DRAW_MARGIN_SIZE)
+	);
 	UWORD uwCalcHeight = pManager->uwBmAvailHeight + blockCountCeil(uwBoundWidth, uwVpWidth) - 1;
 
 	if(pCustomBack) {
@@ -449,7 +464,7 @@ void scrollBufferReset(
 		pManager->uwModulo -= 2;
 	}
 	else {
-		fetchModeApplyScrollBufferXScrollCopper(
+		fetchModeApplyXScrollCopper(
 			pManager->sCommon.pVPort, &pManager->uwDDfStrt, &pManager->uwModulo
 		);
 	}

--- a/src/ace/managers/viewport/scrollbuffer.c
+++ b/src/ace/managers/viewport/scrollbuffer.c
@@ -456,17 +456,9 @@ void scrollBufferReset(
 
 	pManager->uwDDfStrt = fetchModeGetDDfStrt(pManager->sCommon.pVPort);
 	pManager->uwDDfStop = fetchModeGetDDfStop(pManager->sCommon.pVPort);
-	if(pManager->sCommon.pVPort->eFlags & VP_FLAG_HIRES) {
-		pManager->uwDDfStrt -= 8; // for scroll reasons
-
-		// One word more for fetch
-		pManager->uwModulo -= 2;
-	}
-	else {
-		fetchModeApplyXScrollCopper(
-			pManager->sCommon.pVPort, &pManager->uwDDfStrt, &pManager->uwModulo
-		);
-	}
+	fetchModeApplyXScrollCopper(
+		pManager->sCommon.pVPort, &pManager->uwDDfStrt, &pManager->uwModulo
+	);
 	logWrite("DDFSTRT: %04X, DDFSTOP: %04X, Modulo: %u\n", pManager->uwDDfStrt, pManager->uwDDfStop, pManager->uwModulo);
 
 	// Constant stuff in copperlist

--- a/src/ace/managers/viewport/scrollbuffer.c
+++ b/src/ace/managers/viewport/scrollbuffer.c
@@ -238,7 +238,7 @@ static void updateStartCopperlist(tCopCmd *pCmds, const tBitMap *pBitmap, const 
 	}
 }
 
-static void resetBreakCopperlist(tCopCmd *pCmds, const UWORD uwOffsY, const UWORD uwWaitX, const UBYTE ubBpp) {
+static void resetBreakCopperlist(tCopCmd *pCmds, const UWORD uwOffsY, const UBYTE ubBpp) {
 	UBYTE i = 0;
 	// copper jump location & strobe to jump past the break block
 	UBYTE offset = scrollBufferGetRawCopperlistInstructionCountBreak(ubBpp);
@@ -250,21 +250,18 @@ static void resetBreakCopperlist(tCopCmd *pCmds, const UWORD uwOffsY, const UWOR
 	copSetMove(&pCmds[i++].sMove, &g_pCustom->copjmp2, 1);
 
 	// wait & bitplane ptrs
-	copSetWait(&pCmds[i++].sWait, uwWaitX, uwOffsY);
+	copSetWait(&pCmds[i++].sWait, 0, uwOffsY);
 	for(UBYTE j = 0; j < ubBpp; j++) {
 		copSetMove(&pCmds[i++].sMove, &g_pBplFetch[j].uwHi, 0);
 		copSetMove(&pCmds[i++].sMove, &g_pBplFetch[j].uwLo, 0);
 	}
 }
 
-static void updateBreakCopperlist(
-	tCopCmd *pCmds, const tBitMap *pBitmap,
-	const UWORD uwWaitX, const UWORD uwSplitPos, const ULONG ulBplAddX
-) {
+static void updateBreakCopperlist(tCopCmd *pCmds, const tBitMap *pBitmap, const UWORD uwSplitPos, const ULONG ulBplAddX) {
 	pCmds[2].sWait.bfIsSkip = 1; // skip the jump so we have this block enabled
 
 	UBYTE i = 4; // the first 4 bytes are cop2lch, cop2lcl, SKIP/WAIT, cop2jmp
-	copSetWait(&pCmds[i++].sWait, uwWaitX, uwSplitPos);
+	pCmds[i++].sWait.bfWaitY = uwSplitPos;
 	for(UBYTE j = 0; j < pBitmap->Depth; j++) {
 		ULONG ulPlaneAddr = (ULONG)(pBitmap->Planes[j]) + ulBplAddX;
 		copSetMoveVal(&pCmds[i++].sMove, ulPlaneAddr >> 16);
@@ -292,7 +289,6 @@ void scrollBufferProcess(tScrollBufferManager *pManager) {
 
 	// preparations for new copperlist
 	UWORD uwShift = fetchModeCalcBplShift(pManager->sCommon.pVPort, uwScrollX);
-	UWORD uwBreakWaitX = fetchModeGetCopFetchDoneWaitX(pManager->sCommon.pVPort);
 	ULONG ulBplAddX = fetchModeCalcBplOffsetX(pManager->sCommon.pVPort, uwScrollX);
 
 	tCopList *pCopList = pManager->sCommon.pVPort->pView->pCopList;
@@ -305,7 +301,6 @@ void scrollBufferProcess(tScrollBufferManager *pManager) {
 		if(pManager->uwBmAvailHeight - uwScrollY < uwVpHeight) {
 			updateBreakCopperlist(
 				pCmdListBreak, pManager->pBack,
-				uwBreakWaitX,
 				pManager->sCommon.pVPort->pView->ubPosY +
 				pManager->sCommon.pVPort->uwOffsY +
 				pManager->uwBmAvailHeight - uwScrollY - 1,
@@ -338,7 +333,7 @@ void scrollBufferProcess(tScrollBufferManager *pManager) {
 			if(pBlock->ubDisabled) {
 				copBlockEnable(pCopList, pBlock);
 			}
-			copBlockWait(pCopList, pBlock, uwBreakWaitX, (
+			copBlockWait(pCopList, pBlock, fetchModeGetCopWaitX(pManager->sCommon.pVPort), (
 				pManager->sCommon.pVPort->pView->ubPosY +
 				pManager->sCommon.pVPort->uwOffsY +
 				pManager->uwBmAvailHeight - uwScrollY - 1
@@ -477,7 +472,6 @@ void scrollBufferReset(
 	// Constant stuff in copperlist
 	tCopList *pCopList = pManager->sCommon.pVPort->pView->pCopList;
 	if(pManager->ubFlags & SCROLLBUFFER_FLAG_COPLIST_RAW) {
-		UWORD uwBreakWaitX = fetchModeGetCopFetchDoneWaitX(pManager->sCommon.pVPort);
 		resetStartCopperlist(
 			&pCopList->pBackBfr->pList[pManager->uwCopperOffsetStart],
 			pManager
@@ -486,7 +480,6 @@ void scrollBufferReset(
 			&pCopList->pBackBfr->pList[pManager->uwCopperOffsetBreak],
 			pManager->sCommon.pVPort->pView->ubPosY +
 			pManager->sCommon.pVPort->uwOffsY - 1,
-			uwBreakWaitX,
 			pManager->sCommon.pVPort->ubBpp);
 		// again for double bufferred
 		resetStartCopperlist(
@@ -497,7 +490,6 @@ void scrollBufferReset(
 			&pCopList->pFrontBfr->pList[pManager->uwCopperOffsetBreak],
 			pManager->sCommon.pVPort->pView->ubPosY +
 			pManager->sCommon.pVPort->uwOffsY - 1,
-			uwBreakWaitX,
 			pManager->sCommon.pVPort->ubBpp
 		);
 	}

--- a/src/ace/managers/viewport/scrollbuffer.c
+++ b/src/ace/managers/viewport/scrollbuffer.c
@@ -238,7 +238,7 @@ static void updateStartCopperlist(tCopCmd *pCmds, const tBitMap *pBitmap, const 
 	}
 }
 
-static void resetBreakCopperlist(tCopCmd *pCmds, const UWORD uwOffsY, const UBYTE ubBpp) {
+static void resetBreakCopperlist(tCopCmd *pCmds, const UWORD uwOffsY, const UWORD uwWaitX, const UBYTE ubBpp) {
 	UBYTE i = 0;
 	// copper jump location & strobe to jump past the break block
 	UBYTE offset = scrollBufferGetRawCopperlistInstructionCountBreak(ubBpp);
@@ -250,18 +250,21 @@ static void resetBreakCopperlist(tCopCmd *pCmds, const UWORD uwOffsY, const UBYT
 	copSetMove(&pCmds[i++].sMove, &g_pCustom->copjmp2, 1);
 
 	// wait & bitplane ptrs
-	copSetWait(&pCmds[i++].sWait, 0, uwOffsY);
+	copSetWait(&pCmds[i++].sWait, uwWaitX, uwOffsY);
 	for(UBYTE j = 0; j < ubBpp; j++) {
 		copSetMove(&pCmds[i++].sMove, &g_pBplFetch[j].uwHi, 0);
 		copSetMove(&pCmds[i++].sMove, &g_pBplFetch[j].uwLo, 0);
 	}
 }
 
-static void updateBreakCopperlist(tCopCmd *pCmds, const tBitMap *pBitmap, const UWORD uwSplitPos, const ULONG ulBplAddX) {
+static void updateBreakCopperlist(
+	tCopCmd *pCmds, const tBitMap *pBitmap,
+	const UWORD uwWaitX, const UWORD uwSplitPos, const ULONG ulBplAddX
+) {
 	pCmds[2].sWait.bfIsSkip = 1; // skip the jump so we have this block enabled
 
 	UBYTE i = 4; // the first 4 bytes are cop2lch, cop2lcl, SKIP/WAIT, cop2jmp
-	pCmds[i++].sWait.bfWaitY = uwSplitPos;
+	copSetWait(&pCmds[i++].sWait, uwWaitX, uwSplitPos);
 	for(UBYTE j = 0; j < pBitmap->Depth; j++) {
 		ULONG ulPlaneAddr = (ULONG)(pBitmap->Planes[j]) + ulBplAddX;
 		copSetMoveVal(&pCmds[i++].sMove, ulPlaneAddr >> 16);
@@ -289,6 +292,7 @@ void scrollBufferProcess(tScrollBufferManager *pManager) {
 
 	// preparations for new copperlist
 	UWORD uwShift = fetchModeCalcBplShift(pManager->sCommon.pVPort, uwScrollX);
+	UWORD uwBreakWaitX = fetchModeGetCopFetchDoneWaitX(pManager->sCommon.pVPort);
 	ULONG ulBplAddX = fetchModeCalcBplOffsetX(pManager->sCommon.pVPort, uwScrollX);
 
 	tCopList *pCopList = pManager->sCommon.pVPort->pView->pCopList;
@@ -301,6 +305,7 @@ void scrollBufferProcess(tScrollBufferManager *pManager) {
 		if(pManager->uwBmAvailHeight - uwScrollY < uwVpHeight) {
 			updateBreakCopperlist(
 				pCmdListBreak, pManager->pBack,
+				uwBreakWaitX,
 				pManager->sCommon.pVPort->pView->ubPosY +
 				pManager->sCommon.pVPort->uwOffsY +
 				pManager->uwBmAvailHeight - uwScrollY - 1,
@@ -333,7 +338,7 @@ void scrollBufferProcess(tScrollBufferManager *pManager) {
 			if(pBlock->ubDisabled) {
 				copBlockEnable(pCopList, pBlock);
 			}
-			copBlockWait(pCopList, pBlock, fetchModeGetCopWaitX(pManager->sCommon.pVPort), (
+			copBlockWait(pCopList, pBlock, uwBreakWaitX, (
 				pManager->sCommon.pVPort->pView->ubPosY +
 				pManager->sCommon.pVPort->uwOffsY +
 				pManager->uwBmAvailHeight - uwScrollY - 1
@@ -472,6 +477,7 @@ void scrollBufferReset(
 	// Constant stuff in copperlist
 	tCopList *pCopList = pManager->sCommon.pVPort->pView->pCopList;
 	if(pManager->ubFlags & SCROLLBUFFER_FLAG_COPLIST_RAW) {
+		UWORD uwBreakWaitX = fetchModeGetCopFetchDoneWaitX(pManager->sCommon.pVPort);
 		resetStartCopperlist(
 			&pCopList->pBackBfr->pList[pManager->uwCopperOffsetStart],
 			pManager
@@ -480,6 +486,7 @@ void scrollBufferReset(
 			&pCopList->pBackBfr->pList[pManager->uwCopperOffsetBreak],
 			pManager->sCommon.pVPort->pView->ubPosY +
 			pManager->sCommon.pVPort->uwOffsY - 1,
+			uwBreakWaitX,
 			pManager->sCommon.pVPort->ubBpp);
 		// again for double bufferred
 		resetStartCopperlist(
@@ -490,6 +497,7 @@ void scrollBufferReset(
 			&pCopList->pFrontBfr->pList[pManager->uwCopperOffsetBreak],
 			pManager->sCommon.pVPort->pView->ubPosY +
 			pManager->sCommon.pVPort->uwOffsY - 1,
+			uwBreakWaitX,
 			pManager->sCommon.pVPort->ubBpp
 		);
 	}

--- a/src/ace/managers/viewport/scrollbuffer.c
+++ b/src/ace/managers/viewport/scrollbuffer.c
@@ -5,7 +5,6 @@
 #include <ace/managers/viewport/scrollbuffer.h>
 #include <ace/utils/tag.h>
 #include <ace/utils/fetchmode.h>
-#include <ace/generic/screen.h> // Has the look up table for the COPPER_X_WAIT values.
 #include <limits.h>
 
 static UWORD nearestPowerOf2(UWORD uwVal) {

--- a/src/ace/managers/viewport/scrollbuffer.c
+++ b/src/ace/managers/viewport/scrollbuffer.c
@@ -74,7 +74,7 @@ tScrollBufferManager *scrollBufferCreate(void *pTags, ...) {
 			pVPort->pView->pCopList, 2 * pVPort->ubBpp + 8,
 			// Vertically addition from DiWStrt, horizontally just so that 6bpp can be set up.
 			// First to set are ddf, modulos & shift so they are changed during fetch.
-			s_pCopperWaitXByBitplanes[pVPort->ubBpp], pVPort->uwOffsY + pVPort->pView->ubPosY -1
+			fetchModeGetCopWaitX(pVPort), pVPort->uwOffsY + pVPort->pView->ubPosY -1
 		);
 		pManager->pBreakBlock = copBlockCreate(
 			pVPort->pView->pCopList, 2 * pVPort->ubBpp + 2,
@@ -206,7 +206,7 @@ static void resetStartCopperlist(tCopCmd *pCmds, tScrollBufferManager *pManager)
 	);
 	UBYTE ubBpp = pManager->sCommon.pVPort->ubBpp;
 	UBYTE i = 0;
-	copSetWait(&pCmds[i++].sWait, s_pCopperWaitXByBitplanes[ubBpp], uwOffsY);
+	copSetWait(&pCmds[i++].sWait, fetchModeGetCopWaitX(pManager->sCommon.pVPort), uwOffsY);
 	// prepare bitplane ptrs & bplcon commands. will be updated in process
 	copSetMove(&pCmds[i++].sMove, &g_pCustom->bplcon1, 0);
 	for(UBYTE j = 0; j < ubBpp; j++) {
@@ -325,7 +325,7 @@ void scrollBufferProcess(tScrollBufferManager *pManager) {
 			if(pBlock->ubDisabled) {
 				copBlockEnable(pCopList, pBlock);
 			}
-			copBlockWait(pCopList, pBlock, s_pCopperWaitXByBitplanes[pManager->sCommon.pVPort->ubBpp], (
+			copBlockWait(pCopList, pBlock, fetchModeGetCopWaitX(pManager->sCommon.pVPort), (
 				pManager->sCommon.pVPort->pView->ubPosY +
 				pManager->sCommon.pVPort->uwOffsY +
 				pManager->uwBmAvailHeight - uwScrollY - 1
@@ -440,13 +440,10 @@ void scrollBufferReset(
 	// Extra prefetch words are applied per-mode below.
 	pManager->uwModulo = pManager->pBack->BytesPerRow - (uwVpWidth >> 3);
 
-	pManager->uwDDfStrt = (pManager->sCommon.pVPort->pView->ubPosX + 15) / 2 - 16;
-	pManager->uwDDfStop = pManager->uwDDfStrt + fetchModeGetDDfStep(pManager->sCommon.pVPort);
+	pManager->uwDDfStrt = fetchModeGetDDfStrt(pManager->sCommon.pVPort);
+	pManager->uwDDfStop = fetchModeGetDDfStop(pManager->sCommon.pVPort);
 	if(pManager->sCommon.pVPort->eFlags & VP_FLAG_HIRES) {
 		pManager->uwDDfStrt -= 8; // for scroll reasons
-		// Start/stop one 4-step bitplane fetch pattern later: 3120
-		pManager->uwDDfStrt += 4;
-		pManager->uwDDfStop += 4;
 
 		// One word more for fetch
 		pManager->uwModulo -= 2;
@@ -485,7 +482,7 @@ void scrollBufferReset(
 	else {
 		tCopBlock *pBlock = pManager->pStartBlock;
 		// Set initial WAIT
-		copBlockWait(pCopList, pBlock, s_pCopperWaitXByBitplanes[pManager->sCommon.pVPort->ubBpp], (
+		copBlockWait(pCopList, pBlock, fetchModeGetCopWaitX(pManager->sCommon.pVPort), (
 			pManager->sCommon.pVPort->pView->ubPosY +
 			pManager->sCommon.pVPort->uwOffsY - 1
 		));

--- a/src/ace/managers/viewport/simplebuffer.c
+++ b/src/ace/managers/viewport/simplebuffer.c
@@ -7,7 +7,6 @@
 #include <ace/utils/tag.h>
 #include <ace/utils/extview.h>
 #include <ace/utils/fetchmode.h>
-#include <ace/generic/screen.h> // Has the look up table for the COPPER_X_WAIT values.
 #ifdef AMIGA
 
 

--- a/src/ace/managers/viewport/simplebuffer.c
+++ b/src/ace/managers/viewport/simplebuffer.c
@@ -40,7 +40,6 @@ static void simpleBufferInitializeCopperList(
 	pManager->uBfrBounds.uwY = pManager->pFront->Rows;
 	UWORD uwModulo = pManager->pFront->BytesPerRow - (pVPort->uwWidth >> 3);
 
-	// http://amigadev.elowar.com/read/ADCD_2.1/Hardware_Manual_guide/node0085.html
 	UWORD uwDDfStrt = fetchModeGetDDfStrt(pVPort);
 	UWORD uwDDfStop = fetchModeGetDDfStop(pVPort);
 

--- a/src/ace/managers/viewport/simplebuffer.c
+++ b/src/ace/managers/viewport/simplebuffer.c
@@ -42,13 +42,8 @@ static void simpleBufferInitializeCopperList(
 	UWORD uwModulo = pManager->pFront->BytesPerRow - (pVPort->uwWidth >> 3);
 
 	// http://amigadev.elowar.com/read/ADCD_2.1/Hardware_Manual_guide/node0085.html
-	UWORD uwDDfStrt = (pVPort->pView->ubPosX + 15) / 2 - 16;
-	UWORD uwDDFStep = fetchModeGetDDfStep(pVPort);
-	UWORD uwDDfStop = uwDDfStrt + uwDDFStep;
-	if(pVPort->eFlags & VP_FLAG_HIRES) {
-		uwDDfStrt += 4;
-		uwDDfStop += 4;
-	}
+	UWORD uwDDfStrt = fetchModeGetDDfStrt(pVPort);
+	UWORD uwDDfStop = fetchModeGetDDfStop(pVPort);
 
 	if(
 		!isScrollX || pManager->uBfrBounds.uwX <= pVPort->uwWidth
@@ -78,7 +73,7 @@ static void simpleBufferInitializeCopperList(
 			"Setting copperlist %p at offs %u\n",
 			pCopList->pBackBfr, pManager->uwCopperOffset
 		);
-		copSetWait(&pCmdList[0].sWait, s_pCopperWaitXByBitplanes[pManager->sCommon.pVPort->ubBpp], (
+		copSetWait(&pCmdList[0].sWait, fetchModeGetCopWaitX(pManager->sCommon.pVPort), (
 			pManager->sCommon.pVPort->uwOffsY +
 			pManager->sCommon.pVPort->pView->ubPosY -1
 		));
@@ -288,7 +283,7 @@ tSimpleBufferManager *simpleBufferCreate(void *pTags, ...) {
 			pCopList, simpleBufferGetRawCopperlistInstructionCount(pVPort->ubBpp) - 1,
 			// Vertically addition from DiWStrt, horizontally just so that 6bpp can be set up.
 			// First to set are ddf, modulos & shift so they are changed during fetch.
-			s_pCopperWaitXByBitplanes[pVPort->ubBpp],
+			fetchModeGetCopWaitX(pVPort),
 			 pVPort->uwOffsY + pVPort->pView->ubPosY - 1
 		);
 	}

--- a/src/ace/managers/viewport/tilebuffer.c
+++ b/src/ace/managers/viewport/tilebuffer.c
@@ -7,7 +7,6 @@
 #include <ace/managers/blit.h>
 #include <ace/managers/system.h>
 #include <ace/utils/tag.h>
-#include <ace/generic/screen.h> // Has the look up table for the COPPER_X_WAIT values.
 #include <proto/exec.h> // Bartman's compiler needs this
 
 #define TILEBUFFER_MAX_TILESET_SIZE (1 << (8 * sizeof(tTileBufferTileIndex)))

--- a/src/ace/utils/extview.c
+++ b/src/ace/utils/extview.c
@@ -259,6 +259,12 @@ void viewLoad(tView *pView) {
 #ifdef ACE_USE_AGA_FEATURES
 		if(pView->pFirstVPort->eFlags & VP_FLAG_AGA) {
 			UWORD uwBplCon0 = ((0x07 & pView->pFirstVPort->ubBpp) << 12) | BV(9); // BPP + composite output
+			if(
+				(pView->uwFlags & VIEW_FLAG_GLOBAL_HRES) &&
+				(pView->pFirstVPort->eFlags & VP_FLAG_HIRES)
+			) {
+				uwBplCon0 |= BV(15);
+			}
 			if(pView->pFirstVPort->ubBpp & 0x08) {
 				uwBplCon0 |= BV(4);
 			}
@@ -270,13 +276,27 @@ void viewLoad(tView *pView) {
 			}
 		}
 		else {
-			g_pCustom->bplcon0 = (pView->pFirstVPort->ubBpp << 12) | BV(9); // BPP + composite output
+			UWORD uwBplCon0 = (pView->pFirstVPort->ubBpp << 12) | BV(9); // BPP + composite output
+			if(
+				(pView->uwFlags & VIEW_FLAG_GLOBAL_HRES) &&
+				(pView->pFirstVPort->eFlags & VP_FLAG_HIRES)
+			) {
+				uwBplCon0 |= BV(15);
+			}
+			g_pCustom->bplcon0 = uwBplCon0;
 			g_pCustom->bplcon2 = (UWORD)(BV(2) | BV(5));
 		}
 		g_pCustom->fmode = pView->pFirstVPort->ubFmode;
 		g_pCustom->bplcon3 = 0; // AGA fix
 #else
-		g_pCustom->bplcon0 = (pView->pFirstVPort->ubBpp << 12) | BV(9); // BPP + composite output
+		UWORD uwBplCon0 = (pView->pFirstVPort->ubBpp << 12) | BV(9); // BPP + composite output
+		if(
+			(pView->uwFlags & VIEW_FLAG_GLOBAL_HRES) &&
+			(pView->pFirstVPort->eFlags & VP_FLAG_HIRES)
+		) {
+			uwBplCon0 |= BV(15);
+		}
+		g_pCustom->bplcon0 = uwBplCon0;
 		g_pCustom->bplcon2 = (UWORD)(BV(2) | BV(5));
 		g_pCustom->fmode = 0; // AGA fix
 		g_pCustom->bplcon3 = 0; // AGA fix

--- a/src/ace/utils/extview.c
+++ b/src/ace/utils/extview.c
@@ -198,10 +198,41 @@ void viewUpdateGlobalPalette(const tView *pView) {
 #endif // AMIGA
 }
 
-/**
- *  @todo bplcon0 BPP is set up globally - make it only when all vports
- *        are truly of same BPP.
- */
+static UWORD viewBuildBplCon0(const tView *pView) {
+	const tVPort *pVPort = pView->pFirstVPort;
+	UWORD uwBplCon0 = BV(9); // composite output
+
+#ifdef ACE_USE_AGA_FEATURES
+	if(pVPort->eFlags & VP_FLAG_AGA) {
+		uwBplCon0 |= (0x07 & pVPort->ubBpp) << 12;
+		if(pVPort->ubBpp & 0x08) {
+			uwBplCon0 |= BV(4);
+		}
+	}
+	else
+#endif
+	{
+		uwBplCon0 |= pVPort->ubBpp << 12;
+	}
+
+	if((pView->uwFlags & VIEW_FLAG_GLOBAL_HRES) && (pVPort->eFlags & VP_FLAG_HIRES)) {
+		uwBplCon0 |= BV(15);
+	}
+
+	return uwBplCon0;
+}
+
+static UWORD viewBuildBplCon2(UNUSED_ARG const tView *pView) {
+#ifdef ACE_USE_AGA_FEATURES
+	const tVPort *pVPort = pView->pFirstVPort;
+	if((pVPort->eFlags & VP_FLAG_AGA) && pVPort->ubBpp == 6) {
+		/* KILLEHB + Kickstart-style PF/sprite priority (BV(2)|BV(5) == 0x24) */
+		return (UWORD)(BV(2) | BV(5) | BV(9));
+	}
+#endif
+	return (UWORD)(BV(2) | BV(5));
+}
+
 void viewLoad(tView *pView) {
 	logBlockBegin("viewLoad(pView: %p)", pView);
 
@@ -244,64 +275,19 @@ void viewLoad(tView *pView) {
 			}
 		}
 #endif
-		pView->uwBplCon0 = 0;
-		if(pView->uwFlags & VIEW_FLAG_GLOBAL_BPP) {
-			pView->uwBplCon0 |= pView->pFirstVPort->ubBpp << 12;
-		}
-		if(pView->uwFlags & VIEW_FLAG_GLOBAL_HRES) {
-			pView->uwBplCon0 |= ((pView->pFirstVPort->eFlags & VP_FLAG_HIRES) != 0) << 15;
-		}
-		pView->uwBplCon0 |= BV(9); // composite output
 		// TODO: set uwBplCon2 in viewCreate, make the playfield/sprite priority
 		// configurable via tags
 
 		g_sCopManager.pCopList = pView->pCopList;
-#ifdef ACE_USE_AGA_FEATURES
-		if(pView->pFirstVPort->eFlags & VP_FLAG_AGA) {
-			UWORD uwBplCon0 = ((0x07 & pView->pFirstVPort->ubBpp) << 12) | BV(9); // BPP + composite output
-			if(
-				(pView->uwFlags & VIEW_FLAG_GLOBAL_HRES) &&
-				(pView->pFirstVPort->eFlags & VP_FLAG_HIRES)
-			) {
-				uwBplCon0 |= BV(15);
-			}
-			if(pView->pFirstVPort->ubBpp & 0x08) {
-				uwBplCon0 |= BV(4);
-			}
-			g_pCustom->bplcon0 = uwBplCon0;
-
-			if(pView->pFirstVPort->ubBpp == 6) {
-				/* KILLEHB + Kickstart-style PF/sprite priority (BV(2)|BV(5) == 0x24) */
-				g_pCustom->bplcon2 = (UWORD)(BV(2) | BV(5) | BV(9));
-			}
-		}
-		else {
-			UWORD uwBplCon0 = (pView->pFirstVPort->ubBpp << 12) | BV(9); // BPP + composite output
-			if(
-				(pView->uwFlags & VIEW_FLAG_GLOBAL_HRES) &&
-				(pView->pFirstVPort->eFlags & VP_FLAG_HIRES)
-			) {
-				uwBplCon0 |= BV(15);
-			}
-			g_pCustom->bplcon0 = uwBplCon0;
-			g_pCustom->bplcon2 = (UWORD)(BV(2) | BV(5));
-		}
-		g_pCustom->fmode = pView->pFirstVPort->ubFmode;
+		g_pCustom->bplcon0 = viewBuildBplCon0(pView);
+		g_pCustom->bplcon2 = viewBuildBplCon2(pView);
 		g_pCustom->bplcon3 = 0; // AGA fix
-#else
-		UWORD uwBplCon0 = (pView->pFirstVPort->ubBpp << 12) | BV(9); // BPP + composite output
-		if(
-			(pView->uwFlags & VIEW_FLAG_GLOBAL_HRES) &&
-			(pView->pFirstVPort->eFlags & VP_FLAG_HIRES)
-		) {
-			uwBplCon0 |= BV(15);
-		}
-		g_pCustom->bplcon0 = uwBplCon0;
-		g_pCustom->bplcon2 = (UWORD)(BV(2) | BV(5));
-		g_pCustom->fmode = 0; // AGA fix
-		g_pCustom->bplcon3 = 0; // AGA fix
-#endif
 		g_pCustom->bplcon4 = 0x0011; // AGA fix
+#ifdef ACE_USE_AGA_FEATURES
+		g_pCustom->fmode = pView->pFirstVPort->ubFmode;
+#else
+		g_pCustom->fmode = 0; // AGA fix
+#endif
 
 		UWORD uwDiwStartX = pView->ubPosX;
 		UWORD uwDiwStopX = uwDiwStartX + pView->uwWidth - 256;


### PR DESCRIPTION
<!--- Use this only if you've made non-breaking improvements or bugfixes -->

## Description

Fix scroll buffer display setup for higher bit depths and hires modes.

This PR improves scroll buffer behavior for 6bpp and 7bpp in FMODE 0, 1, and 3. FMODE 3 is usable but still shows minor horizontal black-line glitches.

It also fixes hires mode setup by correctly composing and writing `BPLCON0`, and simplifies the related `BPLCON0` and `BPLCON2` logic in `src/ace/utils/extview.c`.

Known limitation: 8bpp scroll buffer modes are still not fixed. They likely need a deeper change to the scrolling/wrapping mechanism because the current Copper update approach appears to exceed available timing.

## Checklist

- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.