### PR TITLE
Fix double-buffer init after reusable bitmap support

### DIFF
--- a/src/ace/managers/viewport/simplebuffer.c
+++ b/src/ace/managers/viewport/simplebuffer.c
@@ -257,7 +257,7 @@ tSimpleBufferManager *simpleBufferCreate(void *pTags, ...) {
 	}
 
 	UBYTE isDblBfr = tagGet(pTags, vaTags, TAG_SIMPLEBUFFER_IS_DBLBUF, 0);
-	if(isDblBfr && pBack == pFront) {
+	if(isDblBfr && (!pBack || pBack == pFront)) {
 		pBack = bitmapCreate(
 			uwBoundWidth, uwBoundHeight, pVPort->ubBpp, ubBitmapFlags
 		);


### PR DESCRIPTION
## Description
Fix double-buffer initialization in `simplebuffer` after reusable bitmap support.

When `TAG_SIMPLEBUFFER_IS_DBLBUF` was enabled without custom front/back bitmaps, the back buffer could remain `NULL`, so a real second buffer was not created. This caused flickering during redraws. The fix ensures a back buffer is allocated when double buffering is requested and no custom back buffer is provided.

## Checklist
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
