### PR TITLE
Add the ability to get pak file by their hash

### DIFF
--- a/include/ace/utils/pak_file.h
+++ b/include/ace/utils/pak_file.h
@@ -36,6 +36,8 @@ tFile *pakFileGetFileByPath(tPakFile *pPakFile, const char *szInternalPath);
 
 tFile *pakFileGetFileByHash(tPakFile *pPakFile, ULONG ulPathHash);
 
+tFile *pakFileGetFileByIndex(tPakFile *pPakFile, UWORD uwIndex);
+
 ULONG pakFileGetPathHash(const char *szPath);
 
 #endif

--- a/include/ace/utils/pak_file.h
+++ b/include/ace/utils/pak_file.h
@@ -32,7 +32,7 @@ tPakFile *pakFileOpen(const char *szPath, UBYTE isUninterrupted);
 
 void pakFileClose(tPakFile *pPakFile);
 
-tFile *pakFileGetFile(tPakFile *pPakFile, const char *szInternalPath);
+tFile *pakFileGetFileByPath(tPakFile *pPakFile, const char *szInternalPath);
 
 tFile *pakFileGetFileByHash(tPakFile *pPakFile, ULONG ulPathHash);
 

--- a/include/ace/utils/pak_file.h
+++ b/include/ace/utils/pak_file.h
@@ -34,6 +34,10 @@ void pakFileClose(tPakFile *pPakFile);
 
 tFile *pakFileGetFile(tPakFile *pPakFile, const char *szInternalPath);
 
+tFile *pakFileGetFileByHash(tPakFile *pPakFile, ULONG ulPathHash);
+
+ULONG pakFileGetPathHash(const char *szPath);
+
 #endif
 
 #ifdef __cplusplus

--- a/src/ace/utils/pak_file.c
+++ b/src/ace/utils/pak_file.c
@@ -394,8 +394,7 @@ static void pakCompressedFlush(UNUSED_ARG void *pData) {
 	// no-op
 }
 
-static UWORD pakFileGetFileIndex(const tPakFile *pPakFile, const char *szPath) {
-	ULONG ulPathHash = adler32Buffer((UBYTE*)szPath, strlen(szPath)); // TODO: Calculate path hash
+static UWORD pakFileGetFileIndexByHash(const tPakFile *pPakFile, ULONG ulPathHash) {
 	for(UWORD i = 0; i < pPakFile->uwFileCount; ++i) {
 		if(pPakFile->pEntries[i].ulPathChecksum == ulPathHash) {
 			return i;
@@ -441,10 +440,17 @@ void pakFileClose(tPakFile *pPakFile) {
 
 tFile *pakFileGetFile(tPakFile *pPakFile, const char *szInternalPath) {
 	logBlockBegin("pakFileGetFile(pPakFile: %p, szInternalPath: '%s')", pPakFile, szInternalPath);
-	UWORD uwFileIndex = pakFileGetFileIndex(pPakFile, szInternalPath);
+	tFile *pFile = pakFileGetFileByHash(pPakFile, pakFileGetPathHash(szInternalPath));
+	logBlockEnd("pakFileGetFile()");
+	return pFile;
+}
+
+tFile *pakFileGetFileByHash(tPakFile *pPakFile, ULONG ulPathHash) {
+	logBlockBegin("pakFileGetFileByHash(pPakFile: %p, ulPathHash: 0x%08lX)", pPakFile, ulPathHash);
+	UWORD uwFileIndex = pakFileGetFileIndexByHash(pPakFile, ulPathHash);
 	if(uwFileIndex == UWORD_MAX) {
 		logWrite("ERR: Can't find subfile in pakfile\n");
-		logBlockEnd("pakFileGetFile()");
+		logBlockEnd("pakFileGetFileByHash()");
 		return 0;
 	}
 	UBYTE isCompressed = pPakFile->pEntries[uwFileIndex].ulSizeUncompressed != pPakFile->pEntries[uwFileIndex].ulSizeData;
@@ -484,8 +490,12 @@ tFile *pakFileGetFile(tPakFile *pPakFile, const char *szInternalPath) {
 		pFile = pCompressedFile;
 	}
 
-	logBlockEnd("pakFileGetFile()");
+	logBlockEnd("pakFileGetFileByHash()");
 	return pFile;
+}
+
+ULONG pakFileGetPathHash(const char *szPath) {
+	return adler32Buffer((UBYTE*)szPath, strlen(szPath)); // TODO: Calculate path hash
 }
 
 #endif

--- a/src/ace/utils/pak_file.c
+++ b/src/ace/utils/pak_file.c
@@ -438,10 +438,10 @@ void pakFileClose(tPakFile *pPakFile) {
 	logBlockEnd("pakFileClose()");
 }
 
-tFile *pakFileGetFile(tPakFile *pPakFile, const char *szInternalPath) {
-	logBlockBegin("pakFileGetFile(pPakFile: %p, szInternalPath: '%s')", pPakFile, szInternalPath);
+tFile *pakFileGetFileByPath(tPakFile *pPakFile, const char *szInternalPath) {
+	logBlockBegin("pakFileGetFileByPath(pPakFile: %p, szInternalPath: '%s')", pPakFile, szInternalPath);
 	tFile *pFile = pakFileGetFileByHash(pPakFile, pakFileGetPathHash(szInternalPath));
-	logBlockEnd("pakFileGetFile()");
+	logBlockEnd("pakFileGetFileByPath()");
 	return pFile;
 }
 

--- a/src/ace/utils/pak_file.c
+++ b/src/ace/utils/pak_file.c
@@ -447,10 +447,22 @@ tFile *pakFileGetFileByPath(tPakFile *pPakFile, const char *szInternalPath) {
 
 tFile *pakFileGetFileByHash(tPakFile *pPakFile, ULONG ulPathHash) {
 	logBlockBegin("pakFileGetFileByHash(pPakFile: %p, ulPathHash: 0x%08lX)", pPakFile, ulPathHash);
-	UWORD uwFileIndex = pakFileGetFileIndexByHash(pPakFile, ulPathHash);
+	tFile *pFile = pakFileGetFileByIndex(pPakFile, pakFileGetFileIndexByHash(pPakFile, ulPathHash));
+	logBlockEnd("pakFileGetFileByHash()");
+	return pFile;
+}
+
+tFile *pakFileGetFileByIndex(tPakFile *pPakFile, UWORD uwFileIndex) {
+	logBlockBegin("pakFileGetFileByIndex(pPakFile: %p, uwFileIndex: %hu)", pPakFile, uwFileIndex);
+	if(uwFileIndex >= pPakFile->uwFileCount) {
+		logWrite("ERR: File index %hu out of range %hu\n", uwFileIndex, pPakFile->uwFileCount);
+		logBlockEnd("pakFileGetFileByIndex()");
+		return 0;
+	}
+
 	if(uwFileIndex == UWORD_MAX) {
 		logWrite("ERR: Can't find subfile in pakfile\n");
-		logBlockEnd("pakFileGetFileByHash()");
+		logBlockEnd("pakFileGetFileByIndex()");
 		return 0;
 	}
 	UBYTE isCompressed = pPakFile->pEntries[uwFileIndex].ulSizeUncompressed != pPakFile->pEntries[uwFileIndex].ulSizeData;
@@ -490,7 +502,7 @@ tFile *pakFileGetFileByHash(tPakFile *pPakFile, ULONG ulPathHash) {
 		pFile = pCompressedFile;
 	}
 
-	logBlockEnd("pakFileGetFileByHash()");
+	logBlockEnd("pakFileGetFileByIndex()");
 	return pFile;
 }
 


### PR DESCRIPTION
## Description
Pak files are awesome, but recompute the path hash every time you open a file.

Added a way to skip the adler32 hashing on every file read if you already know the file hash. Also added a way to get that hash if you don't know it.

Lastly, refactored the original function to avoid code duplication.

Technically, it's possible to go further and have a `pakFileGetFileByIndex` with a public `pakFileGetFileIndex`, but I didn't want to suggest too many changes in this PR.

I wasn't sure what the TODO comment next to the adler32buffer call was about, so I kept it.

## Checklist
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.

