### PR TITLE
Optimize ECS blit setup and skip A1000 idle workaround.

### DIFF
--- a/include/ace/managers/blit.h
+++ b/include/ace/managers/blit.h
@@ -73,7 +73,8 @@ void blitManagerDestroy(void);
 /**
  * @brief Checks if blitter is idle.
  *
- * Polls 2 times, taking A1000 Agnus bug workaround into account.
+ * On OCS, polls twice to work around the A1000 Agnus blitter-done bug.
+ * On ECS/AGA builds the dummy read is omitted.
  *
  * @return 1 if blitter is idle, otherwise 0.
  *
@@ -84,7 +85,8 @@ UBYTE blitIsIdle(void);
 /**
  * @brief Waits until blitter finishes its work.
  *
- * Polls at least 2 times, taking A1000 Agnus bug workaround into account.
+ * On OCS, polls at least twice to work around the A1000 Agnus blitter-done bug.
+ * On ECS/AGA builds the dummy read is omitted.
  *
  * @todo Investigate if autosetting BLITHOG inside it is beneficial.
  *

--- a/src/ace/managers/blit.c
+++ b/src/ace/managers/blit.c
@@ -101,16 +101,20 @@ UBYTE _blitCheck(
 #endif // defined(ACE_DEBUG)
 
 void blitWait(void) {
-	// A1000 Blitter done bug:
-	// The solution is to read hardware register before testing the bit.
+#if !defined(ACE_USE_ECS_FEATURES)
+	// A1000 Blitter done bug: first dmaconr read after blit start can lie.
+	// Fixed on ECS/AGA Agnus - skip the dummy read there.
 	(void)g_pCustom->dmaconr;
+#endif
 	while(g_pCustom->dmaconr & DMAF_BLTDONE) continue;
 }
 
 UBYTE blitIsIdle(void) {
-	// A1000 Blitter done bug:
-	// The solution is to read hardware register before testing the bit.
+#if !defined(ACE_USE_ECS_FEATURES)
+	// A1000 Blitter done bug: first dmaconr read after blit start can lie.
+	// Fixed on ECS/AGA Agnus - skip the dummy read there.
 	(void)g_pCustom->dmaconr;
+#endif
 	if(g_pCustom->dmaconr & DMAF_BLTDONE) {
 		return 0;
 	}
@@ -222,15 +226,16 @@ UBYTE blitUnsafeCopy(
 		g_pCustom->bltcmod = wDstModulo;
 		g_pCustom->bltdmod = wDstModulo;
 		g_pCustom->bltadat = 0xFFFF;
+#if defined(ACE_USE_ECS_FEATURES)
+		g_pCustom->bltsizv = wHeight;
+#endif
 		while(ubPlane--) {
 			blitWait();
 			// This hell of a casting must stay here or else large offsets get bugged!
 			g_pCustom->bltbpt = &pSrc->Planes[ubPlane][ulSrcOffs];
 			g_pCustom->bltcpt = &pDst->Planes[ubPlane][ulDstOffs];
 			g_pCustom->bltdpt = &pDst->Planes[ubPlane][ulDstOffs];
-
 #if defined(ACE_USE_ECS_FEATURES)
-			g_pCustom->bltsizv = wHeight;
 			g_pCustom->bltsizh = uwBlitWords;
 #else
 			g_pCustom->bltsize = (wHeight << HSIZEBITS) | uwBlitWords;
@@ -286,7 +291,6 @@ UBYTE blitUnsafeCopyAligned(
 #else
 		g_pCustom->bltsize = (wHeight << HSIZEBITS) | uwBlitWords;
 #endif
-
 	}
 	else {
 		if(bitmapIsInterleaved(pSrc) || bitmapIsInterleaved(pDst)) {
@@ -303,12 +307,14 @@ UBYTE blitUnsafeCopyAligned(
 		g_pCustom->bltcon1 = 0;
 		g_pCustom->bltcmod = wSrcModulo;
 		g_pCustom->bltdmod = wDstModulo;
+#if defined(ACE_USE_ECS_FEATURES)
+		g_pCustom->bltsizv = wHeight;
+#endif
 		while(ubPlane--) {
 			blitWait();
 			g_pCustom->bltcpt = &pSrc->Planes[ubPlane][ulSrcOffs];
 			g_pCustom->bltdpt = &pDst->Planes[ubPlane][ulDstOffs];
 #if defined(ACE_USE_ECS_FEATURES)
-			g_pCustom->bltsizv = wHeight;
 			g_pCustom->bltsizh = uwBlitWords;
 #else
 			g_pCustom->bltsize = (wHeight << HSIZEBITS) | uwBlitWords;
@@ -454,22 +460,21 @@ UBYTE blitUnsafeCopyMask(
 		g_pCustom->bltcon1 = uwBltCon1;
 		g_pCustom->bltafwm = uwFirstMask;
 		g_pCustom->bltalwm = uwLastMask;
-		g_pCustom->bltapt = (APTR)&pMsk[ulSrcOffs];
 		g_pCustom->bltamod = wSrcModulo;
 		g_pCustom->bltbmod = wSrcModulo;
 		g_pCustom->bltcmod = wDstModulo;
 		g_pCustom->bltdmod = wDstModulo;
-
+#if defined(ACE_USE_ECS_FEATURES)
+		g_pCustom->bltsizv = wHeight;
+#endif
 		while(ubPlane--) {
 			blitWait();
-			// This hell of a casting must stay here or else large offsets get bugged!
+			// Reload: blit advances bltapt even though start offset is unchanged.
 			g_pCustom->bltapt = (APTR)&pMsk[ulSrcOffs];
 			g_pCustom->bltbpt = &pSrc->Planes[ubPlane][ulSrcOffs];
 			g_pCustom->bltcpt = &pDst->Planes[ubPlane][ulDstOffs];
 			g_pCustom->bltdpt = &pDst->Planes[ubPlane][ulDstOffs];
-
 #if defined(ACE_USE_ECS_FEATURES)
-			g_pCustom->bltsizv = wHeight;
 			g_pCustom->bltsizh = uwBlitWords;
 #else
 			g_pCustom->bltsize = (wHeight << HSIZEBITS) | uwBlitWords;
@@ -523,6 +528,9 @@ UBYTE blitUnsafeRect(
 	g_pCustom->bltdmod = wDstModulo;
 	g_pCustom->bltadat = 0xFFFF;
 	g_pCustom->bltbdat = 0;
+#if defined(ACE_USE_ECS_FEATURES)
+	g_pCustom->bltsizv = wHeight;
+#endif
 	ubPlane = 0;
 
 	do {
@@ -534,7 +542,6 @@ UBYTE blitUnsafeRect(
 		g_pCustom->bltcpt = pDst->Planes[ubPlane] + ulDstOffs;
 		g_pCustom->bltdpt = pDst->Planes[ubPlane] + ulDstOffs;
 #if defined(ACE_USE_ECS_FEATURES)
-		g_pCustom->bltsizv = wHeight;
 		g_pCustom->bltsizh = uwBlitWords;
 #else
 		g_pCustom->bltsize = (wHeight << HSIZEBITS) | uwBlitWords;

--- a/src/ace/managers/blit.c
+++ b/src/ace/managers/blit.c
@@ -469,7 +469,7 @@ UBYTE blitUnsafeCopyMask(
 #endif
 		while(ubPlane--) {
 			blitWait();
-			// Reload: blit advances bltapt even though start offset is unchanged.
+			// This hell of a casting must stay here or else large offsets get bugged!
 			g_pCustom->bltapt = (APTR)&pMsk[ulSrcOffs];
 			g_pCustom->bltbpt = &pSrc->Planes[ubPlane][ulSrcOffs];
 			g_pCustom->bltcpt = &pDst->Planes[ubPlane][ulDstOffs];


### PR DESCRIPTION
## Description

Hoist invariant bltsizv out of per-plane loops, drop a redundant pre-loop bltapt, and omit the A1000 dmaconr dummy read on ECS/AGA builds.

## Checklist

- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
